### PR TITLE
Add EnvironmentHelper::~EnvironmentHelper()

### DIFF
--- a/src/BabylonCpp/src/helpers/environment_helper.cpp
+++ b/src/BabylonCpp/src/helpers/environment_helper.cpp
@@ -32,6 +32,10 @@ EnvironmentHelper::EnvironmentHelper(const IEnvironmentHelperOptions& options,
   _setupImageProcessing();
 }
 
+EnvironmentHelper::~EnvironmentHelper()
+{
+}
+
 void EnvironmentHelper::updateOptions(const IEnvironmentHelperOptions& options)
 {
   auto& newOptions = options;


### PR DESCRIPTION
Hi, Visual Studio Debug Mode worked nice without the destructor, but Release mode demands it (otherwise missing symbol at link time)