### PR TITLE
Fix engine

### DIFF
--- a/src/BabylonCpp/include/babylon/interfaces/igl_rendering_context.h
+++ b/src/BabylonCpp/include/babylon/interfaces/igl_rendering_context.h
@@ -2006,11 +2006,11 @@ public:
    * @param border A GLint specifying the width of the border. Must be 0.
    * @param format A GLenum specifying the format of the texel data.
    * @param type A GLenum specifying the data type of the texel data.
-   * @param pixels An Uint8Array pixel source for the texture.
+   * @param pixels An Uint8Array pixel source for the texture (can be nullptr)
    */
   virtual void texImage2D(GLenum target, GLint level, GLint internalformat,
                           GLsizei width, GLsizei height, GLint border,
-                          GLenum format, GLenum type, const Uint8Array& pixels)
+                          GLenum format, GLenum type, const Uint8Array* const pixels)
     = 0;
 
   /**
@@ -2026,26 +2026,6 @@ public:
    * @param pixels An ICanvas pixel source for the texture.
    */
   virtual void texImage2D(GLenum target, GLint level, GLint internalformat,
-                          GLenum format, GLenum type, ICanvas* pixels)
-    = 0;
-
-  /**
-   * @brief Specifies a two-dimensional texture image.
-   * @param target A GLenum specifying the binding point (target) of the active
-   * texture.
-   * @param level A GLint specifying the level of detail. Level 0 is the base
-   * image level and level n is the nth mipmap reduction level.
-   * @param internalformat A GLint specifying the color components in the
-   * texture.
-   * @param width A GLsizei specifying the width of the texture.
-   * @param height A GLsizei specifying the height of the texture.
-   * @param border A GLint specifying the width of the border. Must be 0.
-   * @param format A GLenum specifying the format of the texel data.
-   * @param type A GLenum specifying the data type of the texel data.
-   * @param pixels An ICanvas pixel source for the texture.
-   */
-  virtual void texImage2D(GLenum target, GLint level, GLint internalformat,
-                          GLsizei width, GLsizei height, GLsizei border,
                           GLenum format, GLenum type, ICanvas* pixels)
     = 0;
 

--- a/src/BabylonCpp/src/engines/engine.cpp
+++ b/src/BabylonCpp/src/engines/engine.cpp
@@ -2966,7 +2966,7 @@ InternalTexturePtr Engine::createTexture(
           if (isPot) {
             _gl->texImage2D(GL::TEXTURE_2D, 0, static_cast<int>(internalFormat),
                             img.width, img.height, 0, GL::RGBA,
-                            GL::UNSIGNED_BYTE, img.data);
+                            GL::UNSIGNED_BYTE, &img.data);
             return false;
           }
 
@@ -2999,7 +2999,7 @@ InternalTexturePtr Engine::createTexture(
             _bindTextureDirectly(GL::TEXTURE_2D, source);
             _gl->texImage2D(GL::TEXTURE_2D, 0, static_cast<int>(internalFormat),
                             img.width, img.height, 0, GL::RGBA,
-                            GL::UNSIGNED_BYTE, img.data);
+                            GL::UNSIGNED_BYTE, &img.data);
 
             _gl->texParameteri(GL::TEXTURE_2D, GL::TEXTURE_MAG_FILTER,
                                GL::LINEAR);
@@ -3122,7 +3122,7 @@ void Engine::updateRawTexture(const InternalTexturePtr& texture,
   else {
     auto _internalSizedFomat = static_cast<GL::GLint>(internalSizedFomat);
     _gl->texImage2D(GL::TEXTURE_2D, 0, _internalSizedFomat, texture->width,
-                    texture->height, 0, internalFormat, textureType, data);
+                    texture->height, 0, internalFormat, textureType, &data);
   }
 
   if (texture->generateMipMaps) {
@@ -3625,7 +3625,7 @@ Engine::createRenderTargetTexture(const std::variant<ISize, float>& size,
                     fullOptions.type.value(), fullOptions.format.value())),
                   width, height, 0,
                   _getInternalFormat(fullOptions.format.value()),
-                  _getWebGLTextureType(fullOptions.type.value()), Uint8Array());
+                  _getWebGLTextureType(fullOptions.type.value()), nullptr);
 
   // Create the framebuffer
   auto currentFrameBuffer = _currentFramebuffer;
@@ -4072,7 +4072,7 @@ void Engine::_uploadDataToTextureDirectly(const InternalTexturePtr& texture,
     = static_cast<int>(std::pow(2, std::max(lodMaxHeight - lod, 0)));
 
   _gl->texImage2D(target, lod, internalFormat, width, height, 0, format,
-                  textureType, imageData.uint8Array);
+                  textureType, &imageData.uint8Array);
 }
 
 void Engine::_uploadArrayBufferViewToTexture(const InternalTexturePtr& texture,
@@ -4109,7 +4109,7 @@ void Engine::_uploadImageToTexture(const InternalTexturePtr& texture,
   }
 
   _gl->texImage2D(target, lod, static_cast<int>(internalFormat), image.width,
-                  image.height, 0, format, textureType, image.data);
+                  image.height, 0, format, textureType, &image.data);
   _bindTextureDirectly(bindTarget, nullptr, true);
 }
 
@@ -4178,7 +4178,7 @@ InternalTexturePtr Engine::createRenderTargetCubeTexture(
                     fullOptions.type.value(), fullOptions.format.value())),
                   size.width, size.height, 0,
                   _getInternalFormat(fullOptions.format.value()),
-                  _getWebGLTextureType(fullOptions.type.value()), Uint8Array());
+                  _getWebGLTextureType(fullOptions.type.value()), nullptr);
   }
 
   // Create the framebuffer
@@ -4441,7 +4441,7 @@ InternalTexturePtr Engine::createCubeTexture(
 #else
           gl.texImage2D(faces[index], 0, static_cast<int>(internalFormat),
                         imgs[index].width, imgs[index].height, 0, GL::RGBA,
-                        GL::UNSIGNED_BYTE, imgs[index].data);
+                        GL::UNSIGNED_BYTE, &imgs[index].data);
 #endif
         }
 
@@ -4541,13 +4541,13 @@ void Engine::updateRawCubeTexture(const InternalTexturePtr& texture,
         gl.texImage2D(facesIndex[index], static_cast<int>(level),
                       static_cast<int>(internalSizedFomat), texture->width,
                       texture->height, 0, internalFormat, textureType,
-                      convertedFaceData.uint8Array);
+                      &convertedFaceData.uint8Array);
       }
       else {
         gl.texImage2D(facesIndex[index], static_cast<int>(level),
                       static_cast<int>(internalSizedFomat), texture->width,
                       texture->height, 0, internalFormat, textureType,
-                      faceData.uint8Array);
+                      &faceData.uint8Array);
       }
     }
   }
@@ -4727,7 +4727,7 @@ InternalTexturePtr Engine::createRawCubeTextureFromUrl(
           }
           gl.texImage2D(faceIndex, static_cast<int>(level),
                         static_cast<int>(internalSizedFomat), mipSize, mipSize,
-                        0, internalFormat, textureType, mipFaceData.uint8Array);
+                        0, internalFormat, textureType, &mipFaceData.uint8Array);
         }
       }
 

--- a/src/BabylonCpp/src/engines/scene.cpp
+++ b/src/BabylonCpp/src/engines/scene.cpp
@@ -262,6 +262,7 @@ Scene::Scene(Engine* engine, const std::optional<SceneOptions>& options)
     , _engine{engine ? engine : Engine::LastCreatedEngine()}
     , _animationRatio{1.f}
     , _animationTimeLastSet{false}
+    , _animationTime(0)
     , _renderId{0}
     , _frameId{0}
     , _executeWhenReadyTimeoutId{-1}
@@ -2120,7 +2121,11 @@ void Scene::_animate()
                        * animationTimeScale;
   _animationTime += static_cast<int>(deltaTime);
   _animationTimeLast = now;
-  for (auto& activeAnimatable : _activeAnimatables) {
+
+  // We copy _activeAnimatables before looping since, 
+  // activeAnimatable->_animate can remove items from _scene->_activeAnimatables
+  std::vector<AnimatablePtr> _activeAnimatables_copy = _activeAnimatables;
+  for (auto& activeAnimatable : _activeAnimatables_copy) {
     if (activeAnimatable) {
       activeAnimatable->_animate(std::chrono::milliseconds(_animationTime));
     }

--- a/src/BabylonCpp/src/materials/material_helper.cpp
+++ b/src/BabylonCpp/src/materials/material_helper.cpp
@@ -198,7 +198,7 @@ bool MaterialHelper::PrepareDefinesForAttributes(
         defines.boolDef["BONETEXTURE"] = true;
       }
       else {
-        defines.boolDef["BonesPerMesh"] = (mesh->skeleton()->bones.size() + 1);
+        defines.intDef["BonesPerMesh"] = static_cast<int>((mesh->skeleton()->bones.size() + 1));
         defines.boolDef["BONETEXTURE"]  = false;
       }
     }

--- a/src/SampleLauncher/include/babylon/impl/gl_rendering_context.h
+++ b/src/SampleLauncher/include/babylon/impl/gl_rendering_context.h
@@ -208,12 +208,9 @@ public:
                          GLenum zpass) override;
   void texImage2D(GLenum target, GLint level, GLint internalformat,
                   GLsizei width, GLsizei height, GLint border, GLenum format,
-                  GLenum type, const Uint8Array& pixels) override;
+                  GLenum type, const Uint8Array* const pixels) override;
   void texImage2D(GLenum target, GLint level, GLint internalformat,
                   GLenum format, GLenum type, ICanvas* pixels) override;
-  void texImage2D(GLenum target, GLint level, GLint internalformat,
-                  GLsizei width, GLsizei height, GLsizei border, GLenum format,
-                  GLenum type, ICanvas* pixels) override;
   void texImage3D(GLenum target, GLint level, GLint internalformat,
                   GLsizei width, GLsizei height, GLsizei depth, GLint border,
                   GLenum format, GLenum type,

--- a/src/SampleLauncher/src/impl/gl_rendering_context.cpp
+++ b/src/SampleLauncher/src/impl/gl_rendering_context.cpp
@@ -1113,27 +1113,25 @@ void GLRenderingContext::stencilOpSeparate(GLenum face, GLenum fail,
 void GLRenderingContext::texImage2D(GLenum target, GLint level,
                                     GLint internalformat, GLsizei width,
                                     GLsizei height, GLint border, GLenum format,
-                                    GLenum type, const Uint8Array& pixels)
+                                    GLenum type, const Uint8Array* const pixels)
 {
-  glTexImage2D(target, level, internalformat, width, height, border, format,
-               type, &pixels[0]);
+  if (pixels == nullptr)
+  {
+    glTexImage2D(target, level, internalformat, width, height, border, format,
+      type, nullptr);
+  }
+  else
+  {
+    glTexImage2D(target, level, internalformat, width, height, border, format,
+      type, pixels->data());
+  }
 }
 
 void GLRenderingContext::texImage2D(GLenum /*target*/, GLint /*level*/,
                                     GLint /*internalformat*/, GLenum /*format*/,
                                     GLenum /*type*/, ICanvas* /*pixels*/)
 {
-}
-
-void GLRenderingContext::texImage2D(GLenum target, GLint level,
-                                    GLint internalformat, GLsizei width,
-                                    GLsizei height, GLsizei border,
-                                    GLenum format, GLenum type, ICanvas* pixels)
-{
-  if (!pixels) {
-    glTexImage2D(target, level, internalformat, width, height, border, format,
-                 type, nullptr);
-  }
+#pragma message("TODO: texImage2D is not implemented for ICanvas!")
 }
 
 void GLRenderingContext::texImage3D(GLenum target, GLint level,

--- a/src/SampleLauncher/src/main.cpp
+++ b/src/SampleLauncher/src/main.cpp
@@ -26,7 +26,8 @@ struct ConsoleLogger {
   {
     printf("%s\n", logMessage.toString().c_str());
 #if _MSC_VER
-    OutputDebugString(logMessage.toString().c_str());
+    std::string msg_n = logMessage.toString() + "\n";
+    OutputDebugString(msg_n.c_str());
 #endif
   }
 


### PR DESCRIPTION
Hello again

Here are some more simple bug fixes:

- texImage2D should be able to accept nullptr (this solves many issues in the samples "LoadXXX")
- Fix two bug in the animation:
  - Set _animationTime to 0 a construction
  - Copy __activeAnimatables (vector<AnimatablePtr>) before looping inside _animate()
 because activeAnimatable->_animate can remove items from _scene->_activeAnimatables
- material_helper: BonesPerMesh is an intDef (not a boolDef)
