### PR TITLE
Hud overlay

### DIFF
--- a/src/BabylonCpp/src/engines/scene.cpp
+++ b/src/BabylonCpp/src/engines/scene.cpp
@@ -3048,12 +3048,13 @@ bool Scene::removeGeometry(Geometry* geometry)
     index = static_cast<size_t>(it - geometries.begin());
   }
 
+  std::string id = geometry->id;
   if (index != geometries.size() - 1) {
     auto lastGeometry = geometries.back();
     geometries[index] = lastGeometry;
     if (!geometriesById.empty()) {
       geometriesById[lastGeometry->id] = index;
-      geometriesById.erase(geometry->id);
+      geometriesById.erase(id);
     }
   }
 

--- a/src/BabylonImGui/src/babylon_imgui/run_scene_with_inspector.cpp
+++ b/src/BabylonImGui/src/babylon_imgui/run_scene_with_inspector.cpp
@@ -274,7 +274,6 @@ private:
 
   void renderSandbox()
   {
-    ImGui::ShowDemoWindow();
     ImGui::BeginGroup();
     ImGui::Text("Sandbox : you can edit the code below!");
     ImGui::Text("As soon as you save it, the code will be compiled and the 3D scene will be updated");

--- a/src/BabylonImGui/src/babylon_imgui/run_scene_with_inspector.cpp
+++ b/src/BabylonImGui/src/babylon_imgui/run_scene_with_inspector.cpp
@@ -265,8 +265,12 @@ private:
 
   void render3d()
   {
+#ifdef BABYLON_BUILD_SANDBOX
     bool isInSandboxMode = (_appContext._viewState == ViewState::SandboxEditor);
     ImVec2 sceneSize = isInSandboxMode ? getSceneSizeSmall() : getSceneSize();
+#else
+    ImVec2 sceneSize = getSceneSize();
+#endif
     ImVec2 cursorPosBeforeScene3d = ImGui::GetCursorPos();
     _appContext._sceneWidget->render(sceneSize);
     renderHud(cursorPosBeforeScene3d, sceneSize);

--- a/src/BabylonImGui/src/babylon_imgui/run_scene_with_inspector.cpp
+++ b/src/BabylonImGui/src/babylon_imgui/run_scene_with_inspector.cpp
@@ -164,11 +164,8 @@ private:
     ImGui::SameLine();
 
     ImGui::BeginGroup();
-    ImGui::Text("%s", _appContext._sceneWidget->getRenderableScene()->getName());
-    ImGui::SameLine(0., 100.);
 
     ShowTabBarEnum(ViewStateLabels, &_appContext._viewState);
-
     ImGui::SameLine(0.f, 80.f);
     BABYLON::BabylonLogsWindow::instance().render();
     ImGui::SameLine();
@@ -178,7 +175,10 @@ private:
     ImGui::Separator();
 
     if (_appContext._viewState == ViewState::Scene3d)
+    {
+      ImGui::Text("%s", _appContext._sceneWidget->getRenderableScene()->getName());
       render3d();
+    }
     if (_appContext._viewState == ViewState::SamplesCodeViewer)
       _samplesCodeEditor.render();
     else if (_appContext._viewState == ViewState::SampleBrowser)


### PR DESCRIPTION

> Weird that you had to revert to the C style Font awesome header (since char8_t cannot be converted to char) on MSVC 2019. I took the Font awesome header from IconFontCppHeaders. Should we open an issue report in that git repo for this problem? Having it fixed there makes it easier to keep up to date with future Font awesome changes.

The problem is that with c++2a,  `const char8_t *` cannot be converted to `const char *`. 

Given that ImGui uses c_style strings, there is not much to do with u8 strings. 

See https://godbolt.org/z/O5HeS8 for a demo: it fails with clang if you pass the option `--std=c++2a` 

> I updated the Extrude Polygon Scene and replaced the key bindings by the hud. This seems to be working great as you can see below. A minor remark is that the hud has to be closed before you can change the scene camera position again. Maybe we could make the hud button a toggle button, in that way the controls stay open next to the scene until you press the hud button again. What do you think?

I made the hud an overlay window, that is available in all tabs (not only in the sandbox). It looks like this:
![image](https://user-images.githubusercontent.com/7694091/66270850-4130e400-e858-11e9-9e63-455344bd1a33.png)

-----

I had to solve a problem inside scene.cpp, which was causing the extrude sample to fail. 
I kind-of "fixed" it by adding a copy of `geometry->id`  (see 0d2b0d5d85393c854da497b8065264cc041ea355).

However, let me share with you some aspects that make me worried. Here is an analyse of the bug: the "geometry" pointer is overwritten in a very surprising way:

````cpp
bool Scene::removeGeometry(Geometry* geometry)     // the address pointed to by "geometry" 
{
  size_t index = 0;
  if (!geometriesById.empty()) {
    if (!stl_util::contains(geometriesById, geometry->id)) {
      return false;
    }
    index = geometriesById[geometry->id];
  }
  else {
    auto it = std::find_if(geometries.begin(), geometries.end(),
                           [geometry](const GeometryPtr& _geometry) {
                             return _geometry.get() == geometry;
                           });
    if (it == geometries.end()) {
      return false;
    }
    index = static_cast<size_t>(it - geometries.begin());
  }

  std::string id = geometry->id;
  if (index != geometries.size() - 1) {
    auto lastGeometry = geometries.back();
    geometries[index] = lastGeometry;  // is surreptitiously overwritten here !!!
                         // I "solved" this by keeping a copy of  geometry->id
    if (!geometriesById.empty()) {
      geometriesById[lastGeometry->id] = index;
      geometriesById.erase(id);
    }
  }

  geometries.pop_back();
  
  onGeometryRemovedObservable.notifyObservers(geometry);

  return true;
}
````

So if I may, I have two advices:

##### use `std::erase(std::remove_if()`whenever possible:

I think `removeGeometry()`would be more clear if it was written by using STL's `remove_if `
 (see https://en.cppreference.com/w/cpp/algorithm/remove). 

````cpp
str2.erase(std::remove_if(geometries.begin(), geometries.end(), ...));
````

(beware, you have to use the `erase-remove` idiom, which is quite tricky: remove_if does not actually remove; you have to call erase after.


#### remember that a call to `erase` _invalidates_ the collection iterators

As soon as you call `erase`, any iterator on the collection becomes _invalid_ (as a matter of fact, erase returns _the new valid iterator_). As far as I understand, on linux the bug does not show immediately, but it does under windows.

See for example this commit 72ba769aeaa3e7c449bb1e3ee9924a7661e66168, where I had to to re-compute the begin() and end() iterators after an erase().

I saw some instances where I was afraid that `erase` might be called on a collection which the code is iterating, without updating the iterator. This can lead to undefined behavior.

Let me show you what I understood inside `MergeMeshes`: I am not sure there is an issue, but can you have a look at it?

````cpp
///////////////////////
//  Mesh::MergeMeshes
///////////////////////
Mesh::MergeMeshes(const std::vector<MeshPtr>& meshes, ...)
    ...
    ...
    if (disposeSource) {
        for (const auto& mesh : meshes) // we are iterating on "meshes"
        { 
        if (mesh) {
            // We are calling "mesh->dispose(), which is not const" / this should not compile ?
            mesh->dispose();        // see Mesh::dispose() code below
                ///////////////////////
                //  void Mesh::dispose(bool doNotRecurse, bool disposeMaterialAndTextures): //////
                ///////////////////////
                if (_geometry) {
                    _geometry->releaseForMesh(this, true); // see releaseForMesh code below
                }
                    ///////////////////////
                    //  void Geometry::releaseForMesh(Mesh* mesh, bool shouldDispose) /////
                    ///////////////////////
                        auto it = std::find(_meshes.begin(), _meshes.end(), mesh);
                        if (it == _meshes.end()) {
                            return;
                        }

                       // Is the code below able to erase an element 
                       // inside the collection on which we are iterating  ? (I'm not sure about it)
                        _meshes.erase(it);     

````

Cheers (and sorry for all these lengthy details :-)