### PR TITLE
engine: _previousFrameBuffer : stores the previous frameBuffer

### DIFF
--- a/src/BabylonCpp/include/babylon/engines/engine.h
+++ b/src/BabylonCpp/include/babylon/engines/engine.h
@@ -2800,6 +2800,9 @@ protected:
    * Hidden
    */
   std::shared_ptr<GL::IGLFramebuffer> _currentFramebuffer;
+  // _previousFrameBuffer : stores the previous frameBuffer 
+  // during calls to bindFrameBuffer(), so that unBindFrameBuffer can restore it
+  std::unique_ptr <GL::IGLFramebuffer> _previousFrameBuffer;
 
 private:
   // WebVR

--- a/src/BabylonCpp/src/engines/engine.cpp
+++ b/src/BabylonCpp/src/engines/engine.cpp
@@ -1115,10 +1115,24 @@ void Engine::bindFramebuffer(const InternalTexturePtr& texture,
 
 void Engine::bindUnboundFramebuffer(const GL::IGLFramebufferPtr& framebuffer)
 {
-  if (_currentFramebuffer != framebuffer) {
-    _gl->bindFramebuffer(GL::FRAMEBUFFER, framebuffer.get());
-    _currentFramebuffer = framebuffer;
+  if (_currentFramebuffer == framebuffer)
+    return;
+
+  std::shared_ptr<GL::IGLFramebuffer> realFrameBuffer;
+  if (framebuffer) {
+    realFrameBuffer = framebuffer;
+    auto previousId = _gl->getParameteri(GL::FRAMEBUFFER_BINDING);
+    _previousFrameBuffer = std::make_unique<GL::IGLFramebuffer>(previousId);
   }
+  else {
+    if (_previousFrameBuffer) {
+      realFrameBuffer = std::move(_previousFrameBuffer);
+      _previousFrameBuffer.reset();
+    }
+  }
+
+  _gl->bindFramebuffer(GL::FRAMEBUFFER, realFrameBuffer.get());
+  _currentFramebuffer = framebuffer;
 }
 
 void Engine::unBindFramebuffer(const InternalTexturePtr& texture,


### PR DESCRIPTION
during calls to bindFrameBuffer(), so that unBindFrameBuffer can restore it

This should solve https://github.com/samdauwe/BabylonCpp/issues/40

I opted to do it inside Engine, since I did not want this to escape the engine context.

