### PR TITLE
Fix scenes

### DIFF
--- a/src/BabylonCpp/include/babylon/babylon_stl_util.h
+++ b/src/BabylonCpp/include/babylon/babylon_stl_util.h
@@ -691,7 +691,7 @@ inline void erase_remove_if(Container& c, Predicate p)
 template <typename T>
 inline void remove_vector_elements_equal(std::vector<T>& vec, const T& val)
 {
-  erase_remove_if(vec, [](auto v) { return v == val; });
+  erase_remove_if(vec, [&val](auto v) { return v == val; });
 }
 
 template <typename BaseClass, typename DerivedClass>

--- a/src/BabylonCpp/include/babylon/babylon_stl_util.h
+++ b/src/BabylonCpp/include/babylon/babylon_stl_util.h
@@ -673,17 +673,67 @@ inline std::vector<T> splice(std::vector<T>& v, int index = 0, int howmany = 0,
   }
 }
 
+//////////////////////////////////////////
+//      erase_remove helpers            //
+//////////////////////////////////////////
 template <typename T>
 inline void remove(std::vector<T>& vec, size_t pos)
 {
   vec.erase(vec.begin() + pos);
 }
 
-template <typename C, typename P>
-inline void remove_if(C& c, const P& p)
+template <typename Container, typename Predicate>
+inline void erase_remove_if(Container& c, Predicate p)
 {
   c.erase(std::remove_if(std::begin(c), std::end(c), p), std::end(c));
 }
+
+template <typename T>
+inline void remove_vector_elements_equal(std::vector<T>& vec, const T& val)
+{
+  erase_remove_if(vec, [](auto v) { return v == val; });
+}
+
+template <typename BaseClass, typename DerivedClass>
+inline void remove_vector_elements_equal_ptr(std::vector<BaseClass*>& vec,
+                                             const DerivedClass* const pointer_to_remove)
+{
+  erase_remove_if(vec, 
+    [pointer_to_remove](const BaseClass* const v) { return v == pointer_to_remove; }
+  );
+}
+
+template <typename BaseClass, typename DerivedClass>
+inline void remove_vector_elements_equal_sharedptr(std::vector<std::shared_ptr<BaseClass>>& vec,
+                                                   const DerivedClass* const pointer_to_remove)
+{
+  erase_remove_if(
+    vec,
+    [pointer_to_remove](const std::shared_ptr<BaseClass>& v) { return v.get() == pointer_to_remove; }
+  );
+}
+
+template <typename T, typename SharePtrVectorWrapper>
+inline void remove_vector_elements_equal_sharedptr_wrapped(
+  SharePtrVectorWrapper& wrapped_vector,
+  const T* const pointer_to_remove)
+{
+  auto& vec = static_cast<std::vector<std::shared_ptr<T>>&>(wrapped_vector);
+  remove_vector_elements_equal_sharedptr(vec, pointer_to_remove);
+}
+
+template <typename T, typename SharePtrVectorWrapper>
+inline void remove_vector_elements_equal_ptr_wrapped(SharePtrVectorWrapper& wrapped_vector,
+                                                     const T* const pointer_to_remove)
+{
+  auto& vec = static_cast<std::vector<T *>&>(wrapped_vector);
+  remove_vector_elements_equal_ptr(vec, pointer_to_remove);
+}
+//////////////////////////////////////////
+//  end of erase_remove helpers         //
+//////////////////////////////////////////
+
+
 
 template <typename Container, typename JsStyleSortFunction>
 void sort_js_style(Container container, JsStyleSortFunction fn)

--- a/src/BabylonCpp/src/actions/action_manager.cpp
+++ b/src/BabylonCpp/src/actions/action_manager.cpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 #include <numeric>
 
+#include <babylon/babylon_stl_util.h>
 #include <babylon/actions/action.h>
 #include <babylon/actions/action_event.h>
 #include <babylon/babylon_stl_util.h>
@@ -35,12 +36,7 @@ void ActionManager::dispose(bool /*doNotRecurse*/,
       --ActionManager::Triggers[action->trigger];
     }
   }
-  _scene->actionManagers.erase(
-    std::remove_if(_scene->actionManagers.begin(), _scene->actionManagers.end(),
-                   [this](const AbstractActionManagerPtr& actionManager) {
-                     return actionManager.get() == this;
-                   }),
-    _scene->actionManagers.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_scene->actionManagers, this);
 }
 
 Scene* ActionManager::getScene() const

--- a/src/BabylonCpp/src/animations/animatable.cpp
+++ b/src/BabylonCpp/src/animations/animatable.cpp
@@ -293,13 +293,7 @@ bool Animatable::_animate(const millisecond_t& delay)
   if (!running) {
     if (disposeOnEnd) {
       // Remove from active animatables
-      _scene->_activeAnimatables.erase(std::remove_if(_scene->_activeAnimatables.begin(),
-                                                      _scene->_activeAnimatables.end(),
-                                                      [this](const AnimatablePtr& animatable) {
-                                                        return animatable.get() == this;
-                                                      }),
-                                       _scene->_activeAnimatables.end());
-
+      stl_util::remove_vector_elements_equal_sharedptr(_scene->_activeAnimatables, this);
       // Dispose all runtime animations
 #if 0
       for (const auto& runtimeAnimation : _runtimeAnimations) {

--- a/src/BabylonCpp/src/animations/animation.cpp
+++ b/src/BabylonCpp/src/animations/animation.cpp
@@ -1,5 +1,6 @@
 #include <babylon/animations/animation.h>
 
+#include <babylon/babylon_stl_util.h>
 #include <babylon/animations/_ianimation_state.h>
 #include <babylon/animations/animatable.h>
 #include <babylon/animations/easing/ieasing_function.h>
@@ -224,12 +225,10 @@ void Animation::addEvent(const AnimationEvent& event)
 
 void Animation::removeEvents(float frame)
 {
-  _events.erase(std::remove_if(_events.begin(), _events.end(),
-                               [frame](const AnimationEvent& event) {
-                                 return stl_util::almost_equal(event.frame,
-                                                               frame);
-                               }),
-                _events.end());
+  stl_util::erase_remove_if(
+    _events,
+    [frame](const AnimationEvent& event) { return stl_util::almost_equal(event.frame, frame); }
+  );
 }
 
 std::vector<AnimationEvent>& Animation::getEvents()
@@ -252,11 +251,10 @@ void Animation::deleteRange(const std::string& iName, bool deleteFrames)
       const auto& from = _ranges[iName].from;
       const auto& to   = _ranges[iName].to;
 
-      _keys.erase(std::remove_if(_keys.begin(), _keys.end(),
-                                 [from, to](const IAnimationKey& key) {
-                                   return key.frame >= from && key.frame <= to;
-                                 }),
-                  _keys.end());
+      stl_util::erase_remove_if(
+        _keys,
+        [from, to](const IAnimationKey& key) { return key.frame >= from && key.frame <= to; }
+      );
     }
     _ranges.erase(iName);
   }

--- a/src/BabylonCpp/src/animations/animation_group.cpp
+++ b/src/BabylonCpp/src/animations/animation_group.cpp
@@ -326,14 +326,7 @@ void AnimationGroup::dispose(bool /*doNotRecurse*/,
 {
   _targetedAnimations.clear();
   _animatables.clear();
-
-  _scene->animationGroups.erase(
-    std::remove_if(_scene->animationGroups.begin(),
-                   _scene->animationGroups.end(),
-                   [this](const AnimationGroupPtr& animationGroup) {
-                     return animationGroup.get() == this;
-                   }),
-    _scene->animationGroups.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_scene->animationGroups, this);
 
   onAnimationEndObservable.clear();
   onAnimationGroupEndObservable.clear();

--- a/src/BabylonCpp/src/animations/runtime_animation.cpp
+++ b/src/BabylonCpp/src/animations/runtime_animation.cpp
@@ -173,13 +173,7 @@ bool RuntimeAnimation::isStopped() const
 
 void RuntimeAnimation::dispose()
 {
-  auto& runtimeAnimations = _animation->runtimeAnimations();
-  runtimeAnimations.erase(
-    std::remove_if(runtimeAnimations.begin(), runtimeAnimations.end(),
-                   [this](const RuntimeAnimationPtr& runtimeAnimation) {
-                     return runtimeAnimation.get() == this;
-                   }),
-    runtimeAnimations.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_animation->runtimeAnimations(), this);
 }
 
 void RuntimeAnimation::setValue(const AnimationValue& iCurrentValue,

--- a/src/BabylonCpp/src/bones/bone.cpp
+++ b/src/BabylonCpp/src/bones/bone.cpp
@@ -128,12 +128,7 @@ void Bone::setParent(Bone* iParent, bool updateDifferenceMatrix)
   }
 
   if (_parent) {
-    _parent->children.erase(std::remove_if(_parent->children.begin(),
-                                           _parent->children.end(),
-                                           [this](const BonePtr& bone) {
-                                             return bone.get() == this;
-                                           }),
-                            _parent->children.end());
+    stl_util::remove_vector_elements_equal_sharedptr(_parent->children, this);
   }
 
   _parent = iParent;

--- a/src/BabylonCpp/src/engines/engine.cpp
+++ b/src/BabylonCpp/src/engines/engine.cpp
@@ -4818,12 +4818,7 @@ void Engine::_releaseTexture(InternalTexture* texture)
   // Unbind channels
   unbindAllTextures();
 
-  _internalTexturesCache.erase(std::remove_if(_internalTexturesCache.begin(),
-                                              _internalTexturesCache.end(),
-                                              [&texture](const InternalTexturePtr& _texture) {
-                                                return _texture.get() == texture;
-                                              }),
-                               _internalTexturesCache.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_internalTexturesCache, texture);
 
   // Integrated fixed lod samplers.
   if (texture->_lodTextureHigh) {

--- a/src/BabylonCpp/src/engines/node.cpp
+++ b/src/BabylonCpp/src/engines/node.cpp
@@ -105,12 +105,7 @@ void Node::set_parent(Node* const& iParent)
 
   // Remove self from list of children of parent
   if (_parentNode && !_parentNode->_children.empty()) {
-    _parentNode->_children.erase(std::remove_if(_parentNode->_children.begin(),
-                                                _parentNode->_children.end(),
-                                                [this](const NodePtr& node) {
-                                                  return node.get() == this;
-                                                }),
-                                 _parentNode->_children.end());
+    stl_util::remove_vector_elements_equal_sharedptr(_parentNode->_children, this);
 
     if (!iParent && !_isDisposed) {
       addToSceneRootNodes();

--- a/src/BabylonCpp/src/interfaces/icanvas.cpp
+++ b/src/BabylonCpp/src/interfaces/icanvas.cpp
@@ -83,15 +83,11 @@ void ICanvas::removeMouseEventListener(
 {
   auto& listeners = mouseEventListeners[static_cast<unsigned>(type)];
   // Remove from listeners
-  listeners.erase(
-    std::remove_if(
-      listeners.begin(), listeners.end(),
-      [&listener](
-        const std::function<void(PointerEvent && evt)>& mouseEventListener) {
-        return stl_util::get_address(listener)
-               == stl_util::get_address(mouseEventListener);
-      }),
-    listeners.end());
+  stl_util::erase_remove_if(listeners, 
+    [&listener](const std::function<void(PointerEvent && evt)>& mouseEventListener) {
+      return stl_util::get_address(listener) == stl_util::get_address(mouseEventListener);
+    }
+  );
 }
 
 void ICanvas::removeKeyEventListener(
@@ -99,15 +95,11 @@ void ICanvas::removeKeyEventListener(
 {
   auto& listeners = keyEventListeners[static_cast<unsigned>(type)];
   // Remove from listeners
-  listeners.erase(
-    std::remove_if(
-      listeners.begin(), listeners.end(),
-      [&listener](
-        const std::function<void(KeyboardEvent && evt)>& keyEventListener) {
-        return stl_util::get_address(listener)
-               == stl_util::get_address(keyEventListener);
-      }),
-    listeners.end());
+  stl_util::erase_remove_if(listeners, 
+    [&listener](const std::function<void(KeyboardEvent && evt)>& keyEventListener) {
+      return stl_util::get_address(listener) == stl_util::get_address(keyEventListener);
+    }
+  );
 }
 
 void ICanvas::setFrameSize(int w, int h)

--- a/src/BabylonCpp/src/layer/effect_layer.cpp
+++ b/src/BabylonCpp/src/layer/effect_layer.cpp
@@ -676,12 +676,7 @@ void EffectLayer::dispose()
   _disposeTextureAndPostProcesses();
 
   // Remove from scene
-  _scene->effectLayers.erase(
-    std::remove_if(_scene->effectLayers.begin(), _scene->effectLayers.end(),
-                   [this](const EffectLayerPtr& effectLayer) {
-                     return effectLayer.get() == this;
-                   }),
-    _scene->effectLayers.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_scene->effectLayers, this);
 
   // Callback
   onDisposeObservable.notifyObservers(this);

--- a/src/BabylonCpp/src/layer/layer.cpp
+++ b/src/BabylonCpp/src/layer/layer.cpp
@@ -203,10 +203,7 @@ void Layer::dispose()
 
   // Remove from scene
   auto& layers = _scene->layers;
-  layers.erase(std::remove_if(
-                 layers.begin(), layers.end(),
-                 [this](const LayerPtr& layer) { return layer.get() == this; }),
-               layers.end());
+  stl_util::remove_vector_elements_equal_sharedptr(layers, this);
 
   // Callback
   onDisposeObservable.notifyObservers(this);

--- a/src/BabylonCpp/src/lensflares/lens_flare.cpp
+++ b/src/BabylonCpp/src/lensflares/lens_flare.cpp
@@ -1,5 +1,6 @@
 #include <babylon/lensflares/lens_flare.h>
 
+#include <babylon/babylon_stl_util.h>
 #include <babylon/engines/constants.h>
 #include <babylon/engines/engine.h>
 #include <babylon/lensflares/lens_flare_system.h>
@@ -42,12 +43,7 @@ void LensFlare::dispose()
   }
 
   // Remove from scene
-  _system->lensFlares.erase(
-    std::remove_if(_system->lensFlares.begin(), _system->lensFlares.end(),
-                   [this](const LensFlarePtr& lensFlare) {
-                     return lensFlare.get() == this;
-                   }),
-    _system->lensFlares.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_system->lensFlares, this);
 }
 
 } // end of namespace BABYLON

--- a/src/BabylonCpp/src/lensflares/lens_flare_system.cpp
+++ b/src/BabylonCpp/src/lensflares/lens_flare_system.cpp
@@ -350,13 +350,7 @@ void LensFlareSystem::dispose()
   lensFlares.clear();
 
   // Remove from scene
-  _scene->lensFlareSystems.erase(
-    std::remove_if(_scene->lensFlareSystems.begin(),
-                   _scene->lensFlareSystems.end(),
-                   [this](const LensFlareSystemPtr& fensFlareSystem) {
-                     return fensFlareSystem.get() == this;
-                   }),
-    _scene->lensFlareSystems.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_scene->lensFlareSystems, this);
 }
 
 LensFlareSystemPtr LensFlareSystem::Parse(const json& /*parsedLensFlareSystem*/,

--- a/src/BabylonCpp/src/materials/multi_material.cpp
+++ b/src/BabylonCpp/src/materials/multi_material.cpp
@@ -131,12 +131,7 @@ void MultiMaterial::dispose(bool forceDisposeEffect, bool forceDisposeTextures,
   }
 
   // Remove from scene
-  scene->multiMaterials.erase(
-    std::remove_if(scene->multiMaterials.begin(), scene->multiMaterials.end(),
-                   [this](const MultiMaterialPtr& multiMaterial) {
-                     return multiMaterial.get() == this;
-                   }),
-    scene->multiMaterials.end());
+  stl_util::remove_vector_elements_equal_sharedptr(scene->multiMaterials, this);
 
   Material::dispose(forceDisposeEffect, forceDisposeTextures);
 }

--- a/src/BabylonCpp/src/materials/textures/base_texture.cpp
+++ b/src/BabylonCpp/src/materials/textures/base_texture.cpp
@@ -2,6 +2,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <babylon/babylon_stl_util.h>
 #include <babylon/core/array_buffer_view.h>
 #include <babylon/engines/engine.h>
 #include <babylon/engines/scene.h>
@@ -525,10 +526,7 @@ void BaseTexture::dispose()
   _scene->stopAnimation(this);
 
   // Remove from scene
-  _scene->textures.erase(
-    std::remove_if(_scene->textures.begin(), _scene->textures.end(),
-                   [this](const BaseTexturePtr& baseTexture) { return baseTexture.get() == this; }),
-    _scene->textures.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_scene->textures, this);
 
   _scene->onTextureRemovedObservable.notifyObservers(this);
 

--- a/src/BabylonCpp/src/materials/textures/internal_texture.cpp
+++ b/src/BabylonCpp/src/materials/textures/internal_texture.cpp
@@ -1,5 +1,6 @@
 #include <babylon/materials/textures/internal_texture.h>
 
+#include <babylon/babylon_stl_util.h>
 #include <babylon/core/array_buffer_view.h>
 #include <babylon/engines/constants.h>
 #include <babylon/engines/depth_texture_creation_options.h>
@@ -290,11 +291,7 @@ void InternalTexture::_swapAndDie(const InternalTexturePtr& target)
   }
 
   auto& cache = _engine->getLoadedTexturesCache();
-  cache.erase(std::remove_if(cache.begin(), cache.end(),
-                             [this](const InternalTexturePtr& internalTexture) {
-                               return internalTexture.get() == this;
-                             }),
-              cache.end());
+  stl_util::remove_vector_elements_equal_sharedptr(cache, this);
 
   auto it = std::find(cache.begin(), cache.end(), target);
   if (it == cache.end()) {

--- a/src/BabylonCpp/src/materials/textures/procedurals/procedural_texture.cpp
+++ b/src/BabylonCpp/src/materials/textures/procedurals/procedural_texture.cpp
@@ -572,13 +572,7 @@ void ProceduralTexture::dispose()
     return;
   }
 
-  scene->proceduralTextures.erase(
-    std::remove_if(scene->proceduralTextures.begin(),
-                   scene->proceduralTextures.end(),
-                   [this](const ProceduralTexturePtr& proceduralTexture) {
-                     return proceduralTexture.get() == this;
-                   }),
-    scene->proceduralTextures.end());
+  stl_util::remove_vector_elements_equal_sharedptr(scene->proceduralTextures, this);
 
   auto& vertexBuffer = _vertexBuffers[VertexBuffer::PositionKind];
   if (vertexBuffer) {

--- a/src/BabylonCpp/src/materials/textures/render_target_texture.cpp
+++ b/src/BabylonCpp/src/materials/textures/render_target_texture.cpp
@@ -786,22 +786,10 @@ void RenderTargetTexture::dispose()
     return;
   }
 
-  scene->customRenderTargets.erase(
-    std::remove_if(
-      scene->customRenderTargets.begin(), scene->customRenderTargets.end(),
-      [this](const RenderTargetTexturePtr& renderTargetTexturePtr) {
-        return renderTargetTexturePtr.get() == this;
-      }),
-    scene->customRenderTargets.end());
+  stl_util::remove_vector_elements_equal_sharedptr(scene->customRenderTargets, this);
 
   for (const auto& camera : scene->cameras) {
-    camera->customRenderTargets.erase(
-      std::remove_if(
-        camera->customRenderTargets.begin(), camera->customRenderTargets.end(),
-        [this](const RenderTargetTexturePtr& renderTargetTexturePtr) {
-          return renderTargetTexturePtr.get() == this;
-        }),
-      camera->customRenderTargets.end());
+    stl_util::remove_vector_elements_equal_sharedptr(camera->customRenderTargets, this);
   }
 
   if (depthStencilTexture) {

--- a/src/BabylonCpp/src/materials/uniform_buffer.cpp
+++ b/src/BabylonCpp/src/materials/uniform_buffer.cpp
@@ -549,13 +549,7 @@ void UniformBuffer::dispose()
     return;
   }
 
-  _engine->_uniformBuffers.erase(
-    std::remove_if(_engine->_uniformBuffers.begin(),
-                   _engine->_uniformBuffers.end(),
-                   [this](const UniformBuffer* uniformBuffer) {
-                     return uniformBuffer == this;
-                   }),
-    _engine->_uniformBuffers.end());
+  stl_util::remove_vector_elements_equal_ptr(_engine->_uniformBuffers, this);
 
   if (!_buffer) {
     return;

--- a/src/BabylonCpp/src/meshes/abstract_mesh.cpp
+++ b/src/BabylonCpp/src/meshes/abstract_mesh.cpp
@@ -1515,7 +1515,8 @@ void AbstractMesh::dispose(bool doNotRecurse, bool disposeMaterialAndTextures)
   _intersectionsInProgress.clear();
 
   // Lights
-  for (const auto& light : getScene()->lights) {
+  auto lightsCopy = getScene()->lights;
+  for (const auto& light : lightsCopy) {
     // Included meshes
     stl_util::remove_vector_elements_equal_sharedptr_wrapped(light->includedOnlyMeshes, this); // Checked
 

--- a/src/BabylonCpp/src/meshes/abstract_mesh.cpp
+++ b/src/BabylonCpp/src/meshes/abstract_mesh.cpp
@@ -1466,7 +1466,8 @@ AbstractMesh* AbstractMesh::clone(const std::string& /*name*/, Node* /*newParent
 AbstractMesh& AbstractMesh::releaseSubMeshes()
 {
   if (!subMeshes.empty()) {
-    for (const auto& subMesh : subMeshes) {
+    auto subMeshesCopy = subMeshes; // copy because subMesh->dispose can erase from subMeshes
+    for (const auto& subMesh : subMeshesCopy) {
       subMesh->dispose();
     }
   }

--- a/src/BabylonCpp/src/meshes/abstract_mesh.cpp
+++ b/src/BabylonCpp/src/meshes/abstract_mesh.cpp
@@ -1516,29 +1516,17 @@ void AbstractMesh::dispose(bool doNotRecurse, bool disposeMaterialAndTextures)
   // Lights
   for (const auto& light : getScene()->lights) {
     // Included meshes
-    light->includedOnlyMeshes().erase(
-      std::remove_if(
-        light->includedOnlyMeshes().begin(), light->includedOnlyMeshes().end(),
-        [this](const AbstractMeshPtr& includedOnlyMesh) { return includedOnlyMesh.get() == this; }),
-      light->includedOnlyMeshes().end());
+    stl_util::remove_vector_elements_equal_sharedptr_wrapped(light->includedOnlyMeshes, this); // Checked
 
     // Excluded meshes
-    light->excludedMeshes().erase(std::remove_if(light->excludedMeshes().begin(),
-                                                 light->excludedMeshes().end(),
-                                                 [this](const AbstractMeshPtr& excludedMesh) {
-                                                   return excludedMesh.get() == this;
-                                                 }),
-                                  light->excludedMeshes().end());
+    stl_util::remove_vector_elements_equal_sharedptr_wrapped(light->excludedMeshes, this); // Checked
 
     // Shadow generators
     auto generator = light->getShadowGenerator();
     if (generator) {
       auto shadowMap = generator->getShadowMap();
       if (shadowMap && !shadowMap->renderList().empty()) {
-        shadowMap->renderList().erase(
-          std::remove_if(shadowMap->renderList().begin(), shadowMap->renderList().end(),
-                         [this](const AbstractMesh* mesh) { return mesh == this; }),
-          shadowMap->renderList().end());
+        stl_util::remove_vector_elements_equal_ptr_wrapped(shadowMap->renderList, this);
       }
     }
   }

--- a/src/BabylonCpp/src/meshes/sub_mesh.cpp
+++ b/src/BabylonCpp/src/meshes/sub_mesh.cpp
@@ -469,12 +469,7 @@ void SubMesh::dispose()
   }
 
   // Remove from mesh
-  _mesh->subMeshes.erase(
-    std::remove_if(_mesh->subMeshes.begin(), _mesh->subMeshes.end(),
-                   [this](const std::shared_ptr<SubMesh>& subMesh) {
-                     return subMesh.get() == this;
-                   }),
-    _mesh->subMeshes.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_mesh->subMeshes, this);
 }
 
 std::string SubMesh::getClassName() const

--- a/src/BabylonCpp/src/meshes/sub_mesh.cpp
+++ b/src/BabylonCpp/src/meshes/sub_mesh.cpp
@@ -358,6 +358,9 @@ SubMesh::_intersectTriangles(Ray& ray, const std::vector<Vector3>& positions,
                              const IndicesArray& indices, bool fastCheck,
                              const TrianglePickingPredicate& trianglePredicate)
 {
+  if (positions.empty())
+    return std::nullopt;
+
   std::optional<IntersectionInfo> intersectInfo = std::nullopt;
 
   // Triangles test

--- a/src/BabylonCpp/src/meshes/vertex_data.cpp
+++ b/src/BabylonCpp/src/meshes/vertex_data.cpp
@@ -719,11 +719,13 @@ std::unique_ptr<VertexData> VertexData::CreateRibbon(RibbonOptions& options)
       // if end of one of two consecutive paths reached, go to next existing
       // path
       ++p;
+      if (p == lg.size())
+        continue; // this is not in the js code, but is a probable js code bug
       if (p == lg.size() - 1) {
         // last path of pathArray reached <=> closeArray == true
         shft = idx[0] - idx[p];
         l1   = lg[p] - 1;
-        l2   = lg[0] - 1;
+        l2   = lg[0] - 1; 
       }
       else {
         shft = idx[p + 1] - idx[p];

--- a/src/BabylonCpp/src/particles/base_particle_system.cpp
+++ b/src/BabylonCpp/src/particles/base_particle_system.cpp
@@ -325,12 +325,11 @@ BaseParticleSystem& BaseParticleSystem::_removeGradientAndTexture(
     return *this;
   }
 
-  gradients.erase(std::remove_if(gradients.begin(), gradients.end(),
-                                 [gradient](const ColorGradient& gradientItem) {
-                                   return stl_util::almost_equal(
-                                     gradientItem.gradient, gradient);
-                                 }),
-                  gradients.end());
+  stl_util::erase_remove_if(gradients,
+    [gradient](const ColorGradient& gradientItem) {
+      return stl_util::almost_equal(gradientItem.gradient, gradient);
+    }
+  );
 
   if (texture) {
     texture->dispose();
@@ -347,13 +346,11 @@ BaseParticleSystem& BaseParticleSystem::_removeGradientAndTexture(
     return *this;
   }
 
-  gradients.erase(
-    std::remove_if(gradients.begin(), gradients.end(),
-                   [gradient](const Color3Gradient& gradientItem) {
-                     return stl_util::almost_equal(gradientItem.gradient,
-                                                   gradient);
-                   }),
-    gradients.end());
+  stl_util::erase_remove_if(gradients,
+    [gradient](const Color3Gradient& gradientItem) {
+      return stl_util::almost_equal(gradientItem.gradient, gradient);
+    }
+  );
 
   if (texture) {
     texture->dispose();
@@ -370,13 +367,12 @@ BaseParticleSystem& BaseParticleSystem::_removeGradientAndTexture(
     return *this;
   }
 
-  gradients.erase(
-    std::remove_if(gradients.begin(), gradients.end(),
-                   [gradient](const FactorGradient& gradientItem) {
-                     return stl_util::almost_equal(gradientItem.gradient,
-                                                   gradient);
-                   }),
-    gradients.end());
+  stl_util::erase_remove_if(
+    gradients,
+    [gradient](const FactorGradient& gradientItem) {
+      return stl_util::almost_equal(gradientItem.gradient, gradient);
+    }
+  );
 
   if (texture) {
     texture->dispose();

--- a/src/BabylonCpp/src/particles/gpu_particle_system.cpp
+++ b/src/BabylonCpp/src/particles/gpu_particle_system.cpp
@@ -1423,13 +1423,7 @@ void GPUParticleSystem::dispose(bool disposeTexture,
                                 bool /*disposeMaterialAndTextures*/)
 {
   // Remove from scene
-  _scene->particleSystems.erase(
-    std::remove_if(_scene->particleSystems.begin(),
-                   _scene->particleSystems.end(),
-                   [this](const IParticleSystemPtr& particleSystem) {
-                     return particleSystem.get() == this;
-                   }),
-    _scene->particleSystems.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_scene->particleSystems, this);
 
   _releaseBuffers();
   _releaseVAOs();

--- a/src/BabylonCpp/src/particles/particle_system.cpp
+++ b/src/BabylonCpp/src/particles/particle_system.cpp
@@ -401,13 +401,11 @@ void ParticleSystem::_removeFactorGradient(
     return;
   }
 
-  factorGradients.erase(
-    std::remove_if(factorGradients.begin(), factorGradients.end(),
-                   [&gradient](const FactorGradient& factorGradient) {
-                     return stl_util::almost_equal(factorGradient.gradient,
-                                                   gradient);
-                   }),
-    factorGradients.end());
+  stl_util::erase_remove_if(factorGradients,
+    [&gradient](const FactorGradient& factorGradient) {
+      return stl_util::almost_equal(factorGradient.gradient, gradient);
+    }
+  );
 }
 
 IParticleSystem&
@@ -675,13 +673,11 @@ IParticleSystem& ParticleSystem::removeColorGradient(float gradient)
     return *this;
   }
 
-  _colorGradients.erase(
-    std::remove_if(_colorGradients.begin(), _colorGradients.end(),
-                   [&gradient](const ColorGradient& colorGradient) {
-                     return stl_util::almost_equal(colorGradient.gradient,
-                                                   gradient);
-                   }),
-    _colorGradients.end());
+  stl_util::erase_remove_if(_colorGradients,
+    [&gradient](const ColorGradient& colorGradient) {
+      return stl_util::almost_equal(colorGradient.gradient, gradient);
+    }
+  );
 
   return *this;
 }
@@ -1750,13 +1746,9 @@ void ParticleSystem::dispose(bool disposeTexture,
   }
 
   // Remove from scene
-  _scene->particleSystems.erase(
-    std::remove_if(_scene->particleSystems.begin(),
-                   _scene->particleSystems.end(),
-                   [this](const IParticleSystemPtr& particleSystem) {
-                     return particleSystem.get() == this;
-                   }),
-    _scene->particleSystems.end());
+  stl_util::erase_remove_if(_scene->particleSystems,
+    [this](const IParticleSystemPtr& particleSystem) { return particleSystem.get() == this; }
+    );
 
   _scene->_activeParticleSystems.clear();
 

--- a/src/BabylonCpp/src/physics/physics_impostor.cpp
+++ b/src/BabylonCpp/src/physics/physics_impostor.cpp
@@ -424,15 +424,13 @@ void PhysicsImpostor::unregisterBeforePhysicsStep(
 {
   using Function = std::function<void(PhysicsImpostor * impostor)>;
 
-  _onBeforePhysicsStepCallbacks.erase(
-    std::remove_if(_onBeforePhysicsStepCallbacks.begin(),
-                   _onBeforePhysicsStepCallbacks.end(),
-                   [&func](const Function& f) {
-                     auto ptr1 = func.template target<Function>();
-                     auto ptr2 = f.template target<Function>();
-                     return ptr1 < ptr2;
-                   }),
-    _onBeforePhysicsStepCallbacks.end());
+  stl_util::erase_remove_if(_onBeforePhysicsStepCallbacks, 
+    [&func](const Function& f) {
+      auto ptr1 = func.template target<Function>();
+      auto ptr2 = f.template target<Function>();
+      return ptr1 < ptr2;
+    }
+  );
 }
 
 void PhysicsImpostor::registerAfterPhysicsStep(
@@ -446,15 +444,13 @@ void PhysicsImpostor::unregisterAfterPhysicsStep(
 {
   using Function = std::function<void(PhysicsImpostor * impostor)>;
 
-  _onAfterPhysicsStepCallbacks.erase(
-    std::remove_if(_onAfterPhysicsStepCallbacks.begin(),
-                   _onAfterPhysicsStepCallbacks.end(),
-                   [&func](const Function& f) {
-                     auto ptr1 = func.template target<Function>();
-                     auto ptr2 = f.template target<Function>();
-                     return ptr1 < ptr2;
-                   }),
-    _onAfterPhysicsStepCallbacks.end());
+  stl_util::erase_remove_if(_onAfterPhysicsStepCallbacks,
+    [&func](const Function& f) {
+      auto ptr1 = func.template target<Function>();
+      auto ptr2 = f.template target<Function>();
+      return ptr1 < ptr2;
+    }
+  );
 }
 
 void PhysicsImpostor::registerOnPhysicsCollide()

--- a/src/BabylonCpp/src/postprocesses/post_process.cpp
+++ b/src/BabylonCpp/src/postprocesses/post_process.cpp
@@ -481,20 +481,10 @@ void PostProcess::dispose(Camera* camera)
   _disposeTextures();
 
   if (_scene) {
-    _scene->postProcesses.erase(std::remove_if(_scene->postProcesses.begin(),
-                                               _scene->postProcesses.end(),
-                                               [this](const PostProcessPtr& postprocess) {
-                                                 return postprocess.get() == this;
-                                               }),
-                                _scene->postProcesses.end());
+    stl_util::remove_vector_elements_equal_sharedptr(_scene->postProcesses, this);
   }
   else {
-    _engine->postProcesses.erase(std::remove_if(_engine->postProcesses.begin(),
-                                                _engine->postProcesses.end(),
-                                                [this](const PostProcessPtr& postprocess) {
-                                                  return postprocess.get() == this;
-                                                }),
-                                 _engine->postProcesses.end());
+    stl_util::remove_vector_elements_equal_sharedptr(_engine->postProcesses, this);
   }
 
   if (!pCamera) {

--- a/src/BabylonCpp/src/postprocesses/post_process.cpp
+++ b/src/BabylonCpp/src/postprocesses/post_process.cpp
@@ -448,7 +448,8 @@ EffectPtr PostProcess::apply()
     source = _forcedOutputTexture;
   }
   else {
-    source = inputTexture();
+    if (!_textures.empty())
+      source = inputTexture();
   }
   _effect->_bindTexture("textureSampler", source);
 

--- a/src/BabylonCpp/src/postprocesses/post_process_manager.cpp
+++ b/src/BabylonCpp/src/postprocesses/post_process_manager.cpp
@@ -76,10 +76,9 @@ bool PostProcessManager::_prepareFrame(
     = !iPostProcesses.empty() ? iPostProcesses : camera->_postProcesses;
 
   // Filter out all null elements
-  postProcesses.erase(
-    std::remove_if(postProcesses.begin(), postProcesses.end(),
-                   [](const PostProcessPtr& pp) { return pp == nullptr; }),
-    postProcesses.end());
+  stl_util::erase_remove_if(postProcesses,
+    [](const PostProcessPtr& pp) { return pp == nullptr; }
+  );
 
   if (postProcesses.empty() || !_scene->postProcessesEnabled) {
     return false;
@@ -147,10 +146,9 @@ void PostProcessManager::_finalizeFrame(
     = _postProcesses.empty() ? camera->_postProcesses : _postProcesses;
 
   // Filter out all null elements
-  postProcesses.erase(
-    std::remove_if(postProcesses.begin(), postProcesses.end(),
-                   [](const PostProcessPtr& pp) { return pp == nullptr; }),
-    postProcesses.end());
+  stl_util::erase_remove_if(postProcesses,
+    [](const PostProcessPtr& pp) { return pp == nullptr; }
+  );
 
   if (postProcesses.empty() || !_scene->postProcessesEnabled) {
     return;

--- a/src/BabylonCpp/src/postprocesses/renderpipeline/pipelines/default_rendering_pipeline.cpp
+++ b/src/BabylonCpp/src/postprocesses/renderpipeline/pipelines/default_rendering_pipeline.cpp
@@ -676,12 +676,7 @@ void DefaultRenderingPipeline::addCamera(Camera* camera)
 
 void DefaultRenderingPipeline::removeCamera(Camera* camera)
 {
-  _camerasToBeAttached.erase(std::remove_if(_camerasToBeAttached.begin(),
-                                            _camerasToBeAttached.end(),
-                                            [camera](const CameraPtr& _camera) {
-                                              return _camera.get() == camera;
-                                            }),
-                             _camerasToBeAttached.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_camerasToBeAttached, camera);
   _buildPipeline();
 }
 

--- a/src/BabylonCpp/src/probes/reflection_probe.cpp
+++ b/src/BabylonCpp/src/probes/reflection_probe.cpp
@@ -1,5 +1,6 @@
 #include <babylon/probes/reflection_probe.h>
 
+#include <babylon/babylon_stl_util.h>
 #include <babylon/cameras/camera.h>
 #include <babylon/core/json_util.h>
 #include <babylon/engines/constants.h>
@@ -138,13 +139,7 @@ void ReflectionProbe::setRenderingAutoClearDepthStencil(
 void ReflectionProbe::dispose()
 {
   // Remove from the scene if found
-  _scene->reflectionProbes.erase(
-    std::remove_if(_scene->reflectionProbes.begin(),
-                   _scene->reflectionProbes.end(),
-                   [this](const ReflectionProbePtr& reflectionProbe) {
-                     return reflectionProbe.get() == this;
-                   }),
-    _scene->reflectionProbes.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_scene->reflectionProbes, this);
 
   if (_renderTargetTexture) {
     _renderTargetTexture->dispose();

--- a/src/BabylonCpp/src/sprites/sprite.cpp
+++ b/src/BabylonCpp/src/sprites/sprite.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include <babylon/babylon_stl_util.h>
 #include <babylon/materials/textures/texture.h>
 #include <babylon/math/color4.h>
 #include <babylon/sprites/sprite_manager.h>
@@ -113,12 +114,7 @@ void Sprite::_animate(float deltaTime)
 void Sprite::dispose()
 {
   // Remove from scene
-  _manager->sprites.erase(std::remove_if(_manager->sprites.begin(),
-                                         _manager->sprites.end(),
-                                         [this](const SpritePtr& sprite) {
-                                           return sprite.get() == this;
-                                         }),
-                          _manager->sprites.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_manager->sprites, this);
 }
 
 } // end of namespace BABYLON

--- a/src/BabylonCpp/src/sprites/sprite_manager.cpp
+++ b/src/BabylonCpp/src/sprites/sprite_manager.cpp
@@ -1,5 +1,6 @@
 #include <babylon/sprites/sprite_manager.h>
 
+#include <babylon/babylon_stl_util.h>
 #include <babylon/cameras/camera.h>
 #include <babylon/collisions/picking_info.h>
 #include <babylon/culling/ray.h>
@@ -381,12 +382,7 @@ void SpriteManager::dispose(bool /*doNotRecurse*/,
   }
 
   // Remove from scene
-  _scene->spriteManagers.erase(
-    std::remove_if(_scene->spriteManagers.begin(), _scene->spriteManagers.end(),
-                   [this](const ISpriteManagerPtr& spriteManager) {
-                     return spriteManager.get() == this;
-                   }),
-    _scene->spriteManagers.end());
+  stl_util::remove_vector_elements_equal_sharedptr(_scene->spriteManagers, this);
 
   // Callback
   onDisposeObservable.notifyObservers(this);

--- a/src/Samples/src/samples/animations/pick_and_play_animation_scene.cpp
+++ b/src/Samples/src/samples/animations/pick_and_play_animation_scene.cpp
@@ -14,6 +14,7 @@
 #include <babylon/meshes/mesh_builder.h>
 #include <babylon/meshes/transform_node.h>
 #include <babylon/samples/samples_index.h>
+#include <babylon/core/logging.h>
 
 namespace BABYLON {
 
@@ -201,7 +202,8 @@ public:
             std::static_pointer_cast<Mesh>(mesh)->material = _mat1;
           }
           _pickedMesh->material = _mat2;
-          _animatableColor->restart();
+          if (_animatableColor)
+            _animatableColor->restart();
           return;
         }
       }

--- a/src/Samples/src/samples/samples_index.cpp
+++ b/src/Samples/src/samples/samples_index.cpp
@@ -25,7 +25,6 @@ void SamplesIndex::fillSamplesFailures() const
     {"EdgesRendererScene", {SampleFailureReasonKind::segFault}},
     {"EnvironmentTextureScene", {SampleFailureReasonKind::empty3d}},
     {"FurMaterialScene", {SampleFailureReasonKind::segFault}},
-    {"ImportBabylonJSLogoScene", {SampleFailureReasonKind::segFault, "Bug in PostProcess / empty textures"}},
     {"InnerMeshPointsScene", {SampleFailureReasonKind::segFault}},
     {"IsPointInsideMeshScene", {SampleFailureReasonKind::processHung}},
     {"LevelOfDetailScene", {SampleFailureReasonKind::segFault, "Low FPS / Segfault when dragging the mouse"}},


### PR DESCRIPTION
Hello,

This PR adds the followings:

* Add some erase_remove helpers, which greatly simplifies the code: https://github.com/samdauwe/BabylonCpp/commit/947575299b72ed74b0462e74037d708715663b52

* Add an early return to SubMesh::_intersectTriangle , which correct some examples

* Corrects a bug inside VertexData::CreateRibbon, see https://github.com/samdauwe/BabylonCpp/commit/22d55c7911a0c77d0ec4bf621fb54d15533c4a89
This commit could be backported to js

* Same issue as discussed yesterday, in another place: `AbstractMesh::clone() / dispose()` makes a copy of the vector before iterating on it, because subMesh->dispose can erase from subMeshes... 

* Correct a bug in pick_and_play_animation_scene

* Correct EffectPtr PostProcess::apply : check that texture are not empty. This solves ImportBabylonJSLogoScene / ImportCandleScene / ImportDudeScene
You may want to double check this one, I am not sure this was the correct way to handle this bug.


