### PR TITLE
Fix compil

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,8 @@ Checks:         '
 
                 hicpp-use-equals-default,
 
+                -bugprone-narrowing-conversions,
+
                 -clang-analyzer-optin.performance.Padding,
                 -clang-analyzer-security.insecureAPI.rand,
                 -clang-analyzer-security.FloatLoopCounter,
@@ -18,6 +20,8 @@ Checks:         '
                 -modernize-use-nodiscard,
                 -modernize-avoid-c-arrays,
                 -modernize-pass-by-value,
+                -modernize-make-shared,
+                -modernize-concat-nested-namespaces,
 
                 -readability-magic-numbers,
                 -readability-uppercase-literal-suffix,
@@ -26,6 +30,8 @@ Checks:         '
                 -readability-convert-member-functions-to-static,
                 -readability-isolate-declaration,
                 -readability-named-parameter,
+                -readability-else-after-return,
+                -readability-redundant-string-init,
 
                 -misc-non-private-member-variables-in-classes,
                 -misc-definitions-in-headers,

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -190,29 +190,6 @@ if(OPTION_MORE_WARNINGS)
   build_string("EXTRA_FLAGS" "${WFLAGS_STR}")
 endif()
 
-# Add -stdlib=libc++ when using Clang if possible
-if(NOT OPTION_NO_AUTO_LIBCPP AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(CXXFLAGS_BACKUP "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_EXE_LINKER_FLAGS_BACKUP "${CMAKE_EXE_LINKER_FLAGS}")
-  set(CMAKE_CXX_FLAGS "-std=c++1y -stdlib=libc++")
-  set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} "-lstdc++")
-  try_run(ProgramResult
-          CompilationSucceeded
-          "${CMAKE_CURRENT_BINARY_DIR}"
-          "${CMAKE_MODULE_PATH}/get_compiler_version.cpp"
-          RUN_OUTPUT_VARIABLE CompilerVersion)
-  if(NOT CompilationSucceeded OR NOT ProgramResult EQUAL 0)
-    message(STATUS "Use clang with GCC' libstdc++")
-  else()
-    message(STATUS "Automatically added '-stdlib=libc++' flag "
-                   "(OPTION_NO_AUTO_LIBCPP not defined)")
-    set(EXTRA_FLAGS "${EXTRA_FLAGS} -stdlib=libc++")
-    set(EXTRA_LINKER_FLAGS "-lstdc++")
-  endif()
-  # Restore CXX flags
-  set(CMAKE_CXX_FLAGS "${CXXFLAGS_BACKUP}")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS_BACKUP}")
-endif()
 
 # Allow unused private fields when using clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")

--- a/src/BabylonCpp/include/babylon/actions/conditions/value_condition.h
+++ b/src/BabylonCpp/include/babylon/actions/conditions/value_condition.h
@@ -83,8 +83,7 @@ public:
    * @param operator the conditional operator, default ValueCondition.IsEqual
    */
   ValueCondition(ActionManager* actionManager, const IAnimatablePtr& target,
-                 const std::string& propertyPath, AnimationValue* value,
-                 unsigned int operatorType = ValueCondition::IsEqual());
+                 const std::string& propertyPath);
   ~ValueCondition() override; // = default
 
   /** Methods **/
@@ -113,7 +112,7 @@ public:
 
 private:
   std::string _propertyPath;
-  unsigned int _operatorType;
+  // unsigned int _operatorType;
 
   /**
    * Internal only
@@ -130,7 +129,7 @@ private:
    */
   std::string _property;
 
-  AnimationValue* _value;
+  // AnimationValue* _value;
 
 }; // end of class ValueCondition
 

--- a/src/BabylonCpp/include/babylon/animations/easing/circle_ease.h
+++ b/src/BabylonCpp/include/babylon/animations/easing/circle_ease.h
@@ -32,7 +32,7 @@ public:
   [[nodiscard]] float easeInCore(float gradient) const override;
 
 protected:
-  CircleEase();
+  CircleEase() = default;
 
 }; // end of class CircleEase
 

--- a/src/BabylonCpp/include/babylon/animations/easing/cubic_ease.h
+++ b/src/BabylonCpp/include/babylon/animations/easing/cubic_ease.h
@@ -32,7 +32,7 @@ public:
   [[nodiscard]] float easeInCore(float gradient) const override;
 
 protected:
-  CubicEase();
+  CubicEase() = default;
 
 }; // end of class CubicEase
 

--- a/src/BabylonCpp/include/babylon/animations/easing/quadratic_ease.h
+++ b/src/BabylonCpp/include/babylon/animations/easing/quadratic_ease.h
@@ -32,7 +32,7 @@ public:
   [[nodiscard]] float easeInCore(float gradient) const override;
 
 protected:
-  QuadraticEase();
+  QuadraticEase() = default;
 
 }; // end of class QuadraticEase
 

--- a/src/BabylonCpp/include/babylon/animations/easing/quartic_ease.h
+++ b/src/BabylonCpp/include/babylon/animations/easing/quartic_ease.h
@@ -32,7 +32,7 @@ public:
   [[nodiscard]] float easeInCore(float gradient) const override;
 
 protected:
-  QuarticEase();
+  QuarticEase() = default;
 
 }; // end of class QuarticEase
 

--- a/src/BabylonCpp/include/babylon/animations/easing/quintic_ease.h
+++ b/src/BabylonCpp/include/babylon/animations/easing/quintic_ease.h
@@ -32,7 +32,7 @@ public:
   [[nodiscard]] float easeInCore(float gradient) const override;
 
 protected:
-  QuinticEase();
+  QuinticEase() = default;
 
 }; // end of class QuinticEase
 

--- a/src/BabylonCpp/include/babylon/animations/easing/sine_ease.h
+++ b/src/BabylonCpp/include/babylon/animations/easing/sine_ease.h
@@ -32,7 +32,7 @@ public:
   [[nodiscard]] float easeInCore(float gradient) const override;
 
 protected:
-  SineEase();
+  SineEase() = default;
 
 }; // end of class SineEase
 

--- a/src/BabylonCpp/include/babylon/babylon_common.h
+++ b/src/BabylonCpp/include/babylon/babylon_common.h
@@ -159,7 +159,7 @@ public:
   WriteOnlyProperty& operator=(const WriteOnlyProperty&) = delete;
   WriteOnlyProperty(const WriteOnlyProperty&)            = delete;
 
-  C& operator=(T theValue)
+  C& operator=(T theValue) // NOLINT
   {
     (_object->*_setter)(theValue);
     return *_object;
@@ -186,7 +186,7 @@ public:
   WriteOnlyProperty& operator=(const WriteOnlyProperty&) = delete;
   WriteOnlyProperty(const WriteOnlyProperty&)            = delete;
 
-  C& operator=(const T& newValue)
+  C& operator=(const T& newValue) // NOLINT
   {
     (_object->*_setter)(newValue);
     return *_object;
@@ -240,7 +240,7 @@ public:
     return _attribute ? (_object->*_attribute) : (_object->*_getter)();
   }
 
-  C& operator=(T newValue)
+  C& operator=(T newValue) // NOLINT
   {
     if (_attribute) {
       (_object->*_attribute) = newValue;
@@ -306,7 +306,7 @@ public:
     return _attribute ? (_object->*_attribute) : (_object->*_getter)();
   }
 
-  C& operator=(const T& newValue)
+  C& operator=(const T& newValue) // NOLINT
   {
     if (_attribute) {
       (_object->*_attribute) = newValue;

--- a/src/BabylonCpp/include/babylon/behaviors/meshes/attach_to_box_behavior.h
+++ b/src/BabylonCpp/include/babylon/behaviors/meshes/attach_to_box_behavior.h
@@ -58,7 +58,7 @@ public:
 
 private:
   FaceDirectionInfo _closestFace(const Vector3& targetDirection);
-  void _lookAtToRef(const Vector3& pos, Quaternion& ref, const Vector3 up = Vector3(0.f, 1.f, 0.f));
+  void _lookAtToRef(const Vector3& pos, Quaternion& ref, Vector3 up = Vector3(0.f, 1.f, 0.f));
 
 public:
   /**

--- a/src/BabylonCpp/include/babylon/behaviors/meshes/face_direction_info.h
+++ b/src/BabylonCpp/include/babylon/behaviors/meshes/face_direction_info.h
@@ -20,7 +20,7 @@ struct BABYLON_SHARED_EXPORT FaceDirectionInfo {
   ~FaceDirectionInfo(); // = default
   [[nodiscard]] FaceDirectionInfo copy() const;
   [[nodiscard]] std::unique_ptr<FaceDirectionInfo> clone() const;
-  friend std::ostream& operator<<(std::ostream& os, const FaceDirectionInfo& arc);
+  friend std::ostream& operator<<(std::ostream& os, const FaceDirectionInfo& faceDirectionInfo);
   friend bool operator==(const FaceDirectionInfo& lhs, const FaceDirectionInfo& rhs);
   friend bool operator!=(const FaceDirectionInfo& lhs, const FaceDirectionInfo& rhs);
 

--- a/src/BabylonCpp/include/babylon/cameras/arc_rotate_camera.h
+++ b/src/BabylonCpp/include/babylon/cameras/arc_rotate_camera.h
@@ -148,7 +148,7 @@ public:
    * zooming on the mesh (this can happen if the mesh is big and the maxradius
    * pretty small for instance)
    */
-  void zoomOn(const std::vector<AbstractMeshPtr> meshes, bool doNotUpdateMaxZ = false);
+  void zoomOn(const std::vector<AbstractMeshPtr>& meshes, bool doNotUpdateMaxZ = false);
 
   /**
    * @brief Focus on a mesh or a bounding box. This adapts the target and

--- a/src/BabylonCpp/include/babylon/cameras/follow_camera_inputs_manager.h
+++ b/src/BabylonCpp/include/babylon/cameras/follow_camera_inputs_manager.h
@@ -20,7 +20,7 @@ struct BABYLON_SHARED_EXPORT FollowCameraInputsManager
    * @brief Instantiates a new FollowCameraInputsManager.
    * @param camera Defines the camera the inputs belong to
    */
-  FollowCameraInputsManager(FollowCamera* _camera);
+  FollowCameraInputsManager(FollowCamera* camera);
   ~FollowCameraInputsManager(); // = default
 
   /**

--- a/src/BabylonCpp/include/babylon/cameras/free_camera_inputs_manager.h
+++ b/src/BabylonCpp/include/babylon/cameras/free_camera_inputs_manager.h
@@ -22,7 +22,7 @@ struct BABYLON_SHARED_EXPORT FreeCameraInputsManager
    * @brief Instantiates a new FreeCameraInputsManager.
    * @param camera Defines the camera the inputs belong to
    */
-  FreeCameraInputsManager(FreeCamera* _camera);
+  FreeCameraInputsManager(FreeCamera* iCamera);
   ~FreeCameraInputsManager(); // = default
 
   /**

--- a/src/BabylonCpp/include/babylon/cameras/target_camera.h
+++ b/src/BabylonCpp/include/babylon/cameras/target_camera.h
@@ -163,7 +163,7 @@ protected:
   /**
    * @brief Set the current rotation of the camera.
    */
-  void set_rotation(const Vector3& value);
+  void set_rotation(const Vector3& newRotation);
 
 private:
   /**

--- a/src/BabylonCpp/include/babylon/core/any.h
+++ b/src/BabylonCpp/include/babylon/core/any.h
@@ -268,17 +268,17 @@ public:
 
   some& operator=(some&& s)
   {
-    return assign(std::move(s));
+    return assign(std::move(s)); // NOLINT
   }
-  some& operator=(some const& s)
+  some& operator=(some const& s) // NOLINT
   {
-    return assign(s);
+    return assign(s); // NOLINT
   }
 
   template <typename V, typename = none<decay<V>>>
   some& operator=(V&& v)
   {
-    return assign(std::forward<V>(v));
+    return assign(std::forward<V>(v)); // NOLINT
   }
 
   friend void swap(some& s, some& r)

--- a/src/BabylonCpp/include/babylon/core/hash.h
+++ b/src/BabylonCpp/include/babylon/core/hash.h
@@ -18,7 +18,7 @@ limitations under the License.
 #define BABYLON_CORE_HASH_H
 
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include <babylon/babylon_api.h>

--- a/src/BabylonCpp/include/babylon/core/logging/log_levels_statics.cpp.h
+++ b/src/BabylonCpp/include/babylon/core/logging/log_levels_statics.cpp.h
@@ -9,13 +9,6 @@
 // this file is included by the "BabylonCpp" lib *AND* the "inspector" lib.
 
 namespace BABYLON {
-  constexpr unsigned int LogLevels::LEVEL_QUIET;
-  constexpr unsigned int LogLevels::LEVEL_ERROR;
-  constexpr unsigned int LogLevels::LEVEL_WARN;
-  constexpr unsigned int LogLevels::LEVEL_INFO;
-  constexpr unsigned int LogLevels::LEVEL_DEBUG;
-  constexpr unsigned int LogLevels::LEVEL_TRACE;
-
   const std::vector<std::pair<unsigned int, std::string>> LogLevels::Levels
     = { std::make_pair(LogLevels::LEVEL_QUIET, "QUIET"),
        std::make_pair(LogLevels::LEVEL_ERROR, "ERROR"),

--- a/src/BabylonCpp/include/babylon/core/logging/logger.h
+++ b/src/BabylonCpp/include/babylon/core/logging/logger.h
@@ -60,7 +60,7 @@ public:
   static LogMessage CreateMessage(unsigned int level, std::string context,
                                   char const* file, int lineNumber,
                                   char const* func, char const* prettyFunc);
-  void log(const LogMessage& logMessage);
+  void log(const LogMessage& msg);
   bool takes(unsigned int level);
 
   bool isSubscribed(unsigned int level, LogMessageListener& logMsgListener);

--- a/src/BabylonCpp/include/babylon/core/string.h
+++ b/src/BabylonCpp/include/babylon/core/string.h
@@ -242,16 +242,11 @@ template <typename T>
 inline bool isDigit(T x)
 {
   std::string s;
-  std::regex e("^-?\\d+", std::regex::optimize);
+  static std::regex e("^-?\\d+", std::regex::optimize);
   std::stringstream ss;
   ss << x;
   ss >> s;
-  if (std::regex_match(s, e)) {
-    return true;
-  }
-  else {
-    return false;
-  }
+  return std::regex_match(s, e);
 }
 
 /**

--- a/src/BabylonCpp/include/babylon/engines/engine.h
+++ b/src/BabylonCpp/include/babylon/engines/engine.h
@@ -936,7 +936,7 @@ public:
    * @param instancesCount defines the number of instances to draw (if
    * instanciation is enabled)
    */
-  virtual void drawElementsType(unsigned int fillMode, int indexStart, int verticesCount,
+  virtual void drawElementsType(unsigned int fillMode, int indexStart, int indexCount,
                                 int instancesCount = 0);
 
   /**

--- a/src/BabylonCpp/include/babylon/engines/processors/shader_processor.h
+++ b/src/BabylonCpp/include/babylon/engines/processors/shader_processor.h
@@ -30,7 +30,7 @@ class BABYLON_SHARED_EXPORT ShaderProcessor {
 
 public:
   static void Process(const std::string& sourceCode, ProcessingOptions& options,
-                      const std::function<void(const std::string& migratedCode)> callback);
+                      const std::function<void(const std::string& migratedCode)>& callback);
 
 private:
   static std::string _ProcessPrecision(std::string source, const ProcessingOptions& options);

--- a/src/BabylonCpp/include/babylon/engines/scene.h
+++ b/src/BabylonCpp/include/babylon/engines/scene.h
@@ -1765,7 +1765,7 @@ private:
    */
   void _registerTransientComponents();
 
-  void _updatePointerPosition(const PointerEvent evt);
+  void _updatePointerPosition(const PointerEvent& evt);
   void _createUbo();
   void _createAlternateUbo();
   // Pointers handling

--- a/src/BabylonCpp/include/babylon/gamepads/controllers/extended_gamepad_button.h
+++ b/src/BabylonCpp/include/babylon/gamepads/controllers/extended_gamepad_button.h
@@ -14,7 +14,7 @@ class BABYLON_SHARED_EXPORT ExtendedGamepadButton
     : public MutableGamepadButton {
 
 public:
-  ExtendedGamepadButton();
+  ExtendedGamepadButton() = default;
   ExtendedGamepadButton(int value, bool touched, bool pressed);
   ~ExtendedGamepadButton(); // = default
 

--- a/src/BabylonCpp/include/babylon/gizmos/bounding_box_gizmo.h
+++ b/src/BabylonCpp/include/babylon/gizmos/bounding_box_gizmo.h
@@ -52,7 +52,7 @@ public:
    * others.
    * @param axis The list of axis that should be enabled (eg. "xy" or "xyz")
    */
-  void setEnabledRotationAxis(const std::string axis);
+  void setEnabledRotationAxis(const std::string& axis);
 
   /**
    * @brief Enables/disables scaling.

--- a/src/BabylonCpp/include/babylon/inputs/input_manager.h
+++ b/src/BabylonCpp/include/babylon/inputs/input_manager.h
@@ -163,7 +163,7 @@ protected:
   void set_pointerY(int value);
 
 private:
-  void _updatePointerPosition(const PointerEvent evt);
+  void _updatePointerPosition(const PointerEvent& evt);
   void _processPointerMove(std::optional<PickingInfo>& pickResult, const PointerEvent& evt);
   // Pointers handling
   void _setRayOnPointerInfo(PointerInfo& pointerInfo);

--- a/src/BabylonCpp/include/babylon/interfaces/igl_rendering_context.h
+++ b/src/BabylonCpp/include/babylon/interfaces/igl_rendering_context.h
@@ -2008,7 +2008,7 @@ public:
   virtual void texImage2D(GLenum target, GLint level, GLint internalformat,
                           GLsizei width, GLsizei height, GLint border,
                           GLenum format, GLenum type,
-                          const Uint8Array* const pixels)
+                          const Uint8Array* const pixels) // NOLINT ([readability-avoid-const-params-in-decls])
     = 0;
 
   /**

--- a/src/BabylonCpp/include/babylon/lensflares/lens_flare_system.h
+++ b/src/BabylonCpp/include/babylon/lensflares/lens_flare_system.h
@@ -147,7 +147,7 @@ protected:
    * be a camera, a light or a mesh).
    * @param scene Define the scene the lens flare system belongs to
    */
-  LensFlareSystem(const std::string name, const LensFlareEmitterType& emitter, Scene* scene);
+  LensFlareSystem(const std::string& name, const LensFlareEmitterType& emitter, Scene* scene);
 
 private:
   [[nodiscard]] bool get_isEnabled() const;

--- a/src/BabylonCpp/include/babylon/materials/iimage_processing_configuration_defines.h
+++ b/src/BabylonCpp/include/babylon/materials/iimage_processing_configuration_defines.h
@@ -28,9 +28,8 @@ struct BABYLON_SHARED_EXPORT IImageProcessingConfigurationDefines {
   bool SAMPLER3DBGRMAP            = false;
   bool IMAGEPROCESSINGPOSTPROCESS = false;
 
-  friend std::ostream&
-  operator<<(std::ostream& os,
-             const IImageProcessingConfigurationDefines& imageProcessingConfigurationDefines);
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const IImageProcessingConfigurationDefines& ipcd);
 
   /**
    * @brief Converts the material define values to a string.

--- a/src/BabylonCpp/include/babylon/materials/multi_material.h
+++ b/src/BabylonCpp/include/babylon/materials/multi_material.h
@@ -77,7 +77,7 @@ public:
    * the parent instance
    * @returns the cloned material
    */
-  [[nodiscard]] MaterialPtr clone(const std::string& _name,
+  [[nodiscard]] MaterialPtr clone(const std::string& iName,
                                   bool cloneChildren = false) const override;
 
   /**

--- a/src/BabylonCpp/include/babylon/materials/multi_material.h
+++ b/src/BabylonCpp/include/babylon/materials/multi_material.h
@@ -119,7 +119,7 @@ protected:
    * @param name Define the name in the scene
    * @param scene Define the scene the material belongs to
    */
-  MultiMaterial(const std::string name, Scene* scene);
+  MultiMaterial(const std::string& name, Scene* scene);
 
   /**
    * @brief Gets the list of Materials used within the multi material.

--- a/src/BabylonCpp/include/babylon/materials/node/blocks/input/input_value.h
+++ b/src/BabylonCpp/include/babylon/materials/node/blocks/input/input_value.h
@@ -14,7 +14,7 @@
 #include <babylon/maths/vector4.h>
 
 #ifndef isNan
-#define isNan(a) (a != a)
+#define isNan(a) ((a) != (a))
 #endif
 
 namespace BABYLON {

--- a/src/BabylonCpp/include/babylon/materials/node/optimizers/node_material_optimizer.h
+++ b/src/BabylonCpp/include/babylon/materials/node/optimizers/node_material_optimizer.h
@@ -15,7 +15,7 @@ using NodeMaterialBlockPtr = std::shared_ptr<NodeMaterialBlock>;
  * @brief Root class for all node material optimizers.
  */
 struct BABYLON_SHARED_EXPORT NodeMaterialOptimizer {
-
+  virtual ~NodeMaterialOptimizer() = default;
   /**
    * @brief Function used to optimize a NodeMaterial graph.
    * @param vertexOutputNodes defines the list of output nodes for the vertex

--- a/src/BabylonCpp/include/babylon/maths/scalar.h
+++ b/src/BabylonCpp/include/babylon/maths/scalar.h
@@ -232,7 +232,7 @@ inline float MoveTowards(float current, float target, float maxDelta)
     result = target;
   }
   else {
-    result = current + Scalar::Sign(target - current) * maxDelta;
+    result = current + Scalar::Signf(target - current) * maxDelta;
   }
   return result;
 }

--- a/src/BabylonCpp/include/babylon/maths/vector2.h
+++ b/src/BabylonCpp/include/babylon/maths/vector2.h
@@ -228,7 +228,7 @@ public:
    * @param scale defines the scaling factor
    * @returns a new Vector2
    */
-  [[nodiscard]] Vector2 scale(float scaleVal) const;
+  [[nodiscard]] Vector2 scale(float iScale) const;
 
   /**
    * @brief Scale the current Vector2 values by a factor to a given Vector2.

--- a/src/BabylonCpp/include/babylon/meshes/mesh.h
+++ b/src/BabylonCpp/include/babylon/meshes/mesh.h
@@ -850,7 +850,7 @@ public:
    * @returns the Mesh.
    */
   Mesh& applyDisplacementMap(const std::string& url, float minHeight, float maxHeight,
-                             const std::function<void(Mesh* mesh)> onSuccess = nullptr,
+                             std::function<void(Mesh* mesh)> onSuccess = nullptr,
                              const std::optional<Vector2>& uvOffset          = std::nullopt,
                              const std::optional<Vector2>& uvScale           = std::nullopt,
                              bool boolforceUpdate                            = false);

--- a/src/BabylonCpp/include/babylon/meshes/vertex_buffer.h
+++ b/src/BabylonCpp/include/babylon/meshes/vertex_buffer.h
@@ -159,7 +159,7 @@ public:
    * @param normalized whether the data contains normalized data (optional)
    * @param useBytes set to true if stride and offset are in bytes (optional)
    */
-  VertexBuffer(Engine* engine, const std::variant<Float32Array, Buffer*> data,
+  VertexBuffer(Engine* engine, const std::variant<Float32Array, Buffer*>& data,
                const std::string& kind, bool updatable,
                const std::optional<bool>& postponeInternalCreation = std::nullopt,
                std::optional<size_t> stride                        = std::nullopt,

--- a/src/BabylonCpp/include/babylon/misc/environment_texture_info.h
+++ b/src/BabylonCpp/include/babylon/misc/environment_texture_info.h
@@ -29,8 +29,7 @@ public:
    * @param parsedEnvironmentTextureInfo defines EnvironmentTextureInfo data
    * @returns the parsed raw texture data
    */
-  static EnvironmentTextureInfoPtr
-  Parse(const json& parsedEnvironmentTextureInfo);
+  static EnvironmentTextureInfoPtr Parse(const json& parsedManifest);
 
 public:
   /**

--- a/src/BabylonCpp/include/babylon/misc/file_tools.h
+++ b/src/BabylonCpp/include/babylon/misc/file_tools.h
@@ -73,9 +73,9 @@ public:
   static void LoadFile(
     std::string url,
     const std::function<void(const std::variant<std::string, ArrayBuffer>& data,
-                             const std::string& responseURL)>& callback,
-    const std::function<void(const ProgressEvent& event)>& progressCallBack = nullptr,
-    bool useArrayBuffer                                                     = false,
+                             const std::string& responseURL)>& onSuccess,
+    const std::function<void(const ProgressEvent& event)>& onProgress = nullptr,
+    bool useArrayBuffer                                               = false,
     const std::function<void(const std::string& message, const std::string& exception)>& onError
     = nullptr);
 
@@ -93,7 +93,7 @@ public:
    * @param buffer the string holding the image data
    * @return the decoded image
    */
-  static Image StringToImage(const std::string& buffer, bool flipVertically = false);
+  static Image StringToImage(const std::string& uri, bool flipVertically = false);
 
 private:
   /**

--- a/src/BabylonCpp/include/babylon/postprocesses/blur_post_process.h
+++ b/src/BabylonCpp/include/babylon/postprocesses/blur_post_process.h
@@ -75,7 +75,7 @@ protected:
    * the constructor. The updateEffect method can be used to compile the shader
    * at a later time. (default: false)
    */
-  BlurPostProcess(const std::string& name, const Vector2& direction, float kernel,
+  BlurPostProcess(const std::string& name, const Vector2& iDrection, float kernel,
                   const std::variant<float, PostProcessOptions>& options, const CameraPtr& camera,
                   std::optional<unsigned int> samplingMode = std::nullopt, Engine* engine = nullptr,
                   bool reusable              = false,

--- a/src/BabylonCpp/include/babylon/postprocesses/fxaa_post_process.h
+++ b/src/BabylonCpp/include/babylon/postprocesses/fxaa_post_process.h
@@ -30,7 +30,7 @@ public:
   ~FxaaPostProcess() override; // = default
 
 protected:
-  FxaaPostProcess(const std::string& _name, float ratio, const CameraPtr& camera = nullptr,
+  FxaaPostProcess(const std::string& iName, float ratio, const CameraPtr& camera = nullptr,
                   unsigned int samplingMode = TextureConstants::BILINEAR_SAMPLINGMODE,
                   Engine* engine = nullptr, bool reusable = false,
                   unsigned int textureType = Constants::TEXTURETYPE_UNSIGNED_INT);

--- a/src/BabylonCpp/src/actions/action_manager.cpp
+++ b/src/BabylonCpp/src/actions/action_manager.cpp
@@ -116,7 +116,7 @@ bool ActionManager::get_hasPickTriggers() const
 bool ActionManager::HasTriggers()
 {
   return std::accumulate(ActionManager::Triggers.begin(),
-                         ActionManager::Triggers.end(), 0)
+                         ActionManager::Triggers.end(), 0u)
          != 0;
 }
 
@@ -126,7 +126,7 @@ bool ActionManager::HasPickTriggers()
   const auto end   = ActionManager::OnPickUpTrigger + 1;
 
   return std::accumulate(ActionManager::Triggers.begin() + start,
-                         ActionManager::Triggers.begin() + end, 0)
+                         ActionManager::Triggers.begin() + end, 0u)
          != 0;
 }
 

--- a/src/BabylonCpp/src/actions/conditions/value_condition.cpp
+++ b/src/BabylonCpp/src/actions/conditions/value_condition.cpp
@@ -8,13 +8,10 @@ namespace BABYLON {
 
 ValueCondition::ValueCondition(ActionManager* actionManager,
                                const IAnimatablePtr& target,
-                               const std::string& propertyPath,
-                               AnimationValue* value, unsigned int operatorType)
+                               const std::string& propertyPath)
     : Condition{actionManager}
     , _propertyPath{propertyPath}
-    , _operatorType{operatorType}
     , _target{target}
-    , _value{value}
 {
   _effectiveTarget = _getEffectiveTarget(target, propertyPath);
   _property        = _getProperty(propertyPath);

--- a/src/BabylonCpp/src/actions/valueactions/interpolate_value_action.cpp
+++ b/src/BabylonCpp/src/actions/valueactions/interpolate_value_action.cpp
@@ -52,7 +52,7 @@ void InterpolateValueAction::execute(const std::optional<IActionEvent>& /*evt*/)
 
   auto animation
     = Animation::New("InterpolateValueAction", _property,
-                     static_cast<size_t>(100 * (1000.f / duration)),
+                     static_cast<size_t>(100 * (1000.f / float(duration))),
                      dataType.value(), Animation::ANIMATIONLOOPMODE_CONSTANT());
 
   animation->setKeys(keys);

--- a/src/BabylonCpp/src/animations/easing/circle_ease.cpp
+++ b/src/BabylonCpp/src/animations/easing/circle_ease.cpp
@@ -6,10 +6,6 @@
 
 namespace BABYLON {
 
-CircleEase::CircleEase()
-{
-}
-
 CircleEase::~CircleEase() = default;
 
 float CircleEase::easeInCore(float gradient) const

--- a/src/BabylonCpp/src/animations/easing/cubic_ease.cpp
+++ b/src/BabylonCpp/src/animations/easing/cubic_ease.cpp
@@ -2,10 +2,6 @@
 
 namespace BABYLON {
 
-CubicEase::CubicEase()
-{
-}
-
 CubicEase::~CubicEase() = default;
 
 float CubicEase::easeInCore(float gradient) const

--- a/src/BabylonCpp/src/animations/easing/quadratic_ease.cpp
+++ b/src/BabylonCpp/src/animations/easing/quadratic_ease.cpp
@@ -2,10 +2,6 @@
 
 namespace BABYLON {
 
-QuadraticEase::QuadraticEase()
-{
-}
-
 QuadraticEase::~QuadraticEase() = default;
 
 float QuadraticEase::easeInCore(float gradient) const

--- a/src/BabylonCpp/src/animations/easing/quartic_ease.cpp
+++ b/src/BabylonCpp/src/animations/easing/quartic_ease.cpp
@@ -2,10 +2,6 @@
 
 namespace BABYLON {
 
-QuarticEase::QuarticEase()
-{
-}
-
 QuarticEase::~QuarticEase() = default;
 
 float QuarticEase::easeInCore(float gradient) const

--- a/src/BabylonCpp/src/animations/easing/quintic_ease.cpp
+++ b/src/BabylonCpp/src/animations/easing/quintic_ease.cpp
@@ -2,10 +2,6 @@
 
 namespace BABYLON {
 
-QuinticEase::QuinticEase()
-{
-}
-
 QuinticEase::~QuinticEase() = default;
 
 float QuinticEase::easeInCore(float gradient) const

--- a/src/BabylonCpp/src/animations/easing/sine_ease.cpp
+++ b/src/BabylonCpp/src/animations/easing/sine_ease.cpp
@@ -6,10 +6,6 @@
 
 namespace BABYLON {
 
-SineEase::SineEase()
-{
-}
-
 SineEase::~SineEase() = default;
 
 float SineEase::easeInCore(float gradient) const

--- a/src/BabylonCpp/src/cameras/arc_rotate_camera.cpp
+++ b/src/BabylonCpp/src/cameras/arc_rotate_camera.cpp
@@ -649,7 +649,7 @@ void ArcRotateCamera::_onCollisionPositionChange(
   _collisionTriggered = false;
 }
 
-void ArcRotateCamera::zoomOn(const std::vector<AbstractMeshPtr> meshes,
+void ArcRotateCamera::zoomOn(const std::vector<AbstractMeshPtr>& meshes,
                              bool doNotUpdateMaxZ)
 {
   auto _meshes = meshes.empty() ? getScene()->getMeshes() : meshes;

--- a/src/BabylonCpp/src/cameras/camera.cpp
+++ b/src/BabylonCpp/src/cameras/camera.cpp
@@ -666,7 +666,7 @@ bool Camera::get_isRightCamera() const
 
 FreeCameraPtr Camera::leftCamera()
 {
-  if (_rigCameras.size() < 1) {
+  if (_rigCameras.empty()) {
     return nullptr;
   }
   return std::static_pointer_cast<FreeCamera>(_rigCameras[0]);
@@ -682,7 +682,7 @@ FreeCameraPtr Camera::rightCamera()
 
 Vector3* Camera::getLeftTarget()
 {
-  if (_rigCameras.size() < 1) {
+  if (_rigCameras.empty()) {
     return nullptr;
   }
   return &std::static_pointer_cast<TargetCamera>(_rigCameras[0])->getTarget();

--- a/src/BabylonCpp/src/cameras/follow_camera_inputs_manager.cpp
+++ b/src/BabylonCpp/src/cameras/follow_camera_inputs_manager.cpp
@@ -7,8 +7,8 @@
 
 namespace BABYLON {
 
-FollowCameraInputsManager::FollowCameraInputsManager(FollowCamera* iCamera)
-    : CameraInputsManager{iCamera}
+FollowCameraInputsManager::FollowCameraInputsManager(FollowCamera* camera)
+    : CameraInputsManager{camera}
 {
 }
 

--- a/src/BabylonCpp/src/cameras/target_camera.cpp
+++ b/src/BabylonCpp/src/cameras/target_camera.cpp
@@ -195,7 +195,7 @@ void TargetCamera::_updateCache(bool ignoreParentClass)
       _cache.lockedTarget.reset(lockedTargetPosition);
     }
     else {
-      _cache.lockedTarget.get()->copyFrom(*lockedTargetPosition);
+      _cache.lockedTarget->copyFrom(*lockedTargetPosition);
     }
   }
 

--- a/src/BabylonCpp/src/core/hash.cpp
+++ b/src/BabylonCpp/src/core/hash.cpp
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <babylon/core/hash.h>
-#include <ctype.h>
+#include <cctype>
 
 namespace BABYLON {
 

--- a/src/BabylonCpp/src/core/logging/log_message.cpp
+++ b/src/BabylonCpp/src/core/logging/log_message.cpp
@@ -6,8 +6,8 @@
 
 namespace BABYLON {
 
-LogMessage::LogMessage(unsigned int lvl, const std::string& ctx)
-    : _level{lvl}, _context{ctx}
+LogMessage::LogMessage(unsigned int level, const std::string& context)
+    : _level{level}, _context{context}
 {
   // Set timestamp
   _timestamp = Time::systemTimepointNow();
@@ -81,16 +81,16 @@ LogMessage& LogMessage::operator=(LogMessage&& otherLogMessage)
 
 LogMessage::~LogMessage() = default;
 
-std::ostream& operator<<(std::ostream& os, const LogMessage& logMessage)
+std::ostream& operator<<(std::ostream& os, const LogMessage& logMsg)
 {
-  os << '[' << Time::toIso8601Ms(logMessage.timestamp()) << "] "
-     << "[" << std::setw(5) << LogLevels::ToReadableLevel(logMessage.level())
+  os << '[' << Time::toIso8601Ms(logMsg.timestamp()) << "] "
+     << "[" << std::setw(5) << LogLevels::ToReadableLevel(logMsg.level())
      << "] "
-     << "[" << logMessage.context() << "::" << logMessage.function() << "] "
-     << "| " << logMessage.message();
+     << "[" << logMsg.context() << "::" << logMsg.function() << "] "
+     << "| " << logMsg.message();
   // Add file and line number for traces
-  if (logMessage.level() == LogLevels::LEVEL_TRACE) {
-    os << " (" << logMessage.file() << ":" << logMessage.lineNumber() << ")";
+  if (logMsg.level() == LogLevels::LEVEL_TRACE) {
+    os << " (" << logMsg.file() << ":" << logMsg.lineNumber() << ")";
   }
   return os;
 }

--- a/src/BabylonCpp/src/core/logging/logger.cpp
+++ b/src/BabylonCpp/src/core/logging/logger.cpp
@@ -17,12 +17,12 @@ bool LogMessageHandler::takes(unsigned int level)
   return (level >= _minLevel) && (level <= _maxLevel);
 }
 
-void LogMessageHandler::handle(const LogMessage& logMessage)
+void LogMessageHandler::handle(const LogMessage& msg)
 {
-  if (_logMessageListeners.find(logMessage.level())
+  if (_logMessageListeners.find(msg.level())
       != _logMessageListeners.end()) {
-    for (auto& logMsgListener : _logMessageListeners[logMessage.level()]) {
-      (*logMsgListener)(LogMessage(logMessage));
+    for (auto& logMsgListener : _logMessageListeners[msg.level()]) {
+      (*logMsgListener)(LogMessage(msg));
     }
   }
 }

--- a/src/BabylonCpp/src/core/system.cpp
+++ b/src/BabylonCpp/src/core/system.cpp
@@ -6,6 +6,7 @@
 #endif // _WIN32
 #include <babylon/core/filesystem.h>
 #include <babylon/core/system.h>
+#include <babylon/core/logging.h>
 
 namespace BABYLON {
 namespace System {
@@ -32,7 +33,9 @@ void chdirToExecutableFolder()
 #ifdef _WIN32
   _chdir(exeFolder.c_str());
 #else
-  chdir(exeFolder.c_str());
+  int result = chdir(exeFolder.c_str());
+  if (result != 0)
+      BABYLON_LOG_WARN("system.cpp", "chdir to %s failed", exeFolder.c_str());
 #endif
 }
 
@@ -40,7 +43,9 @@ void openBrowser(const std::string &url)
 {
 #ifndef _WIN32
   std::string cmd = std::string("open ") + url;
-  system(cmd.c_str());
+  int result = system(cmd.c_str());
+  if (result != 0)
+    BABYLON_LOG_WARN("system.cpp", "system(%S) failed", cmd.c_str());
 #else
   ShellExecute(0, 0, url.c_str(), 0, 0, SW_SHOW);
 #endif
@@ -50,7 +55,9 @@ void openFile(const std::string &filename)
 {
 #ifndef _WIN32
   std::string cmd = std::string("open ") + BABYLON::Filesystem::absolutePath(filename);
-  system(cmd.c_str());
+  int result = system(cmd.c_str());
+  if (result != 0)
+    BABYLON_LOG_WARN("system.cpp", "system(%S) failed", cmd.c_str());
 #else
   std::string canonical_path = BABYLON::Filesystem::absolutePath(filename);
   ShellExecute(0, 0, canonical_path.c_str(), 0, 0, SW_SHOW);

--- a/src/BabylonCpp/src/engines/engine.cpp
+++ b/src/BabylonCpp/src/engines/engine.cpp
@@ -6045,6 +6045,8 @@ int Engine::GetExponentOfTwo(int value, int max, unsigned int mode)
     case Constants::SCALEMODE_CEILING:
       pot = Engine::CeilingPOT(value);
       break;
+    default:
+      throw std::runtime_error("Engine::GetExponentOfTwo: unexpected mode");
   }
 
   return std::min(pot, max);

--- a/src/BabylonCpp/src/engines/engine.cpp
+++ b/src/BabylonCpp/src/engines/engine.cpp
@@ -827,7 +827,7 @@ void Engine::_renderLoop()
     }
   }
 
-  if (_activeRenderLoops.size() > 0) {
+  if (!_activeRenderLoops.empty()) {
     // Register new frame
   }
   else {

--- a/src/BabylonCpp/src/engines/processors/shader_processor.cpp
+++ b/src/BabylonCpp/src/engines/processors/shader_processor.cpp
@@ -22,7 +22,7 @@
 namespace BABYLON {
 
 void ShaderProcessor::Process(const std::string& sourceCode, ProcessingOptions& options,
-                              const std::function<void(const std::string& migratedCode)> callback)
+                              const std::function<void(const std::string& migratedCode)>& callback)
 {
   _ProcessIncludes(sourceCode, options,
                    [&options, callback](const std::string& codeWithIncludes) -> void {
@@ -302,8 +302,8 @@ std::string ShaderProcessor::_ProcessShaderConversion(const std::string& sourceC
 void ShaderProcessor::_ProcessIncludes(const std::string& sourceCode, ProcessingOptions& options,
                                        const std::function<void(const std::string& data)>& callback)
 {
-  const auto re = "#include<(.+)>(\\((.*)\\))*(\\[(.*)\\])*";
-  std::regex regex(re, std::regex::optimize);
+  static std::string re = R"(#include<(.+)>(\((.*)\))*(\[(.*)\])*)";
+  static std::regex regex(re, std::regex::optimize);
   std::smatch match;
   std::regex_search(sourceCode, match, regex);
 

--- a/src/BabylonCpp/src/engines/processors/shader_processor.cpp
+++ b/src/BabylonCpp/src/engines/processors/shader_processor.cpp
@@ -58,7 +58,7 @@ ShaderDefineExpressionPtr ShaderProcessor::_ExtractOperation(const std::string& 
   std::regex regex(reStr, std::regex::optimize);
   std::smatch match;
 
-  if (std::regex_search(expression, match, regex) && match.size() > 0) {
+  if (std::regex_search(expression, match, regex) && !match.empty()) {
     return std::make_shared<ShaderDefineIsDefinedOperator>(String::trimCopy(match[1]),
                                                            expression[0] == '!');
   }
@@ -172,7 +172,7 @@ bool ShaderProcessor::_MoveCursor(ShaderCodeCursor& cursor, const ShaderCodeNode
     std::regex regex(reKeywords, std::regex::optimize);
     std::smatch matches;
 
-    if (std::regex_search(line, matches, regex) && matches.size() > 0) {
+    if (std::regex_search(line, matches, regex) && !matches.empty()) {
       auto keyword = matches[0];
 
       if (keyword == "#ifdef") {

--- a/src/BabylonCpp/src/engines/scene.cpp
+++ b/src/BabylonCpp/src/engines/scene.cpp
@@ -947,7 +947,7 @@ void Scene::incrementRenderId()
   ++_renderId;
 }
 
-void Scene::_updatePointerPosition(const PointerEvent evt)
+void Scene::_updatePointerPosition(const PointerEvent& evt)
 {
   auto canvasRect = _engine->getRenderingCanvasClientRect();
 

--- a/src/BabylonCpp/src/engines/scene.cpp
+++ b/src/BabylonCpp/src/engines/scene.cpp
@@ -1762,7 +1762,7 @@ bool Scene::isReady()
     auto _mesh = static_cast<Mesh*>(mesh.get());
     auto hardwareInstancedRendering
       = mesh->getClassName() == std::string("InstancedMesh")
-        || (engine->getCaps().instancedArrays && _mesh->instances.size() > 0);
+        || (engine->getCaps().instancedArrays && !_mesh->instances.empty());
 
     // Is Ready For Mesh
     for (const auto& step : _isReadyForMeshStage) {
@@ -1867,7 +1867,7 @@ void Scene::getWaitingItemsCount()
 
 bool Scene::get_isLoading() const
 {
-  return _pendingData.size() > 0;
+  return !_pendingData.empty();
 }
 
 void Scene::executeWhenReady(const std::function<void(Scene* scene, EventState& es)>& func)
@@ -4478,7 +4478,7 @@ Scene::_internalPickSprites(const Ray& ray, const std::function<bool(Sprite* spr
     camera = _activeCamera;
   }
 
-  if (spriteManagers.size() > 0) {
+  if (!spriteManagers.empty()) {
     for (const auto& spriteManager : spriteManagers) {
       if (!spriteManager->isPickable) {
         continue;
@@ -4565,7 +4565,7 @@ std::vector<PickingInfo> Scene::_internalMultiPickSprites(
     camera = activeCamera();
   }
 
-  if (spriteManagers.size() > 0) {
+  if (!spriteManagers.empty()) {
     for (const auto& spriteManager : spriteManagers) {
       if (!spriteManager->isPickable) {
         continue;

--- a/src/BabylonCpp/src/gamepads/controllers/extended_gamepad_button.cpp
+++ b/src/BabylonCpp/src/gamepads/controllers/extended_gamepad_button.cpp
@@ -2,10 +2,6 @@
 
 namespace BABYLON {
 
-ExtendedGamepadButton::ExtendedGamepadButton()
-{
-}
-
 ExtendedGamepadButton::ExtendedGamepadButton(int value, bool touched,
                                              bool pressed)
     : MutableGamepadButton(value, touched, pressed)

--- a/src/BabylonCpp/src/gizmos/bounding_box_gizmo.cpp
+++ b/src/BabylonCpp/src/gizmos/bounding_box_gizmo.cpp
@@ -326,7 +326,7 @@ BoundingBoxGizmo::BoundingBoxGizmo(
   // Hover color change
   std::unordered_map<int, AbstractMeshPtr> pointerIds;
   _pointerObserver
-    = gizmoLayer->utilityLayerScene.get()->onPointerObservable.add(
+    = gizmoLayer->utilityLayerScene->onPointerObservable.add(
       [&](PointerInfo* pointerInfo, EventState& /*es*/) {
         if (!stl_util::contains(pointerIds,
                                 (pointerInfo->pointerEvent).pointerId)) {

--- a/src/BabylonCpp/src/gizmos/bounding_box_gizmo.cpp
+++ b/src/BabylonCpp/src/gizmos/bounding_box_gizmo.cpp
@@ -608,7 +608,7 @@ void BoundingBoxGizmo::_updateScaleBoxes()
   }
 }
 
-void BoundingBoxGizmo::setEnabledRotationAxis(const std::string axis)
+void BoundingBoxGizmo::setEnabledRotationAxis(const std::string& axis)
 {
   size_t i = 0;
   for (auto& m : _rotateSpheresParent->getChildMeshes()) {

--- a/src/BabylonCpp/src/gizmos/plane_rotation_gizmo.cpp
+++ b/src/BabylonCpp/src/gizmos/plane_rotation_gizmo.cpp
@@ -109,8 +109,8 @@ PlaneRotationGizmo::PlaneRotationGizmo(
           _planeNormalTowardsCamera, _rotationMatrix);
       }
       // Flip up vector depending on which side the camera is on
-      if (gizmoLayer->utilityLayerScene.get()->activeCamera()) {
-        auto camVec = gizmoLayer->utilityLayerScene.get()
+      if (gizmoLayer->utilityLayerScene->activeCamera()) {
+        auto camVec = gizmoLayer->utilityLayerScene
                         ->activeCamera()
                         ->position()
                         .subtract(attachedMesh()->position());

--- a/src/BabylonCpp/src/helpers/environment_helper.cpp
+++ b/src/BabylonCpp/src/helpers/environment_helper.cpp
@@ -15,10 +15,6 @@
 
 namespace BABYLON {
 
-constexpr const char* EnvironmentHelper::_groundTextureCDNUrl;
-constexpr const char* EnvironmentHelper::_skyboxTextureCDNUrl;
-constexpr const char* EnvironmentHelper::_environmentTextureCDNUrl;
-
 EnvironmentHelper::EnvironmentHelper(Scene* scene)
     : EnvironmentHelper(EnvironmentHelper::_getDefaultOptions(), scene)
 

--- a/src/BabylonCpp/src/inputs/input_manager.cpp
+++ b/src/BabylonCpp/src/inputs/input_manager.cpp
@@ -91,7 +91,7 @@ void InputManager::set_pointerY(int value)
   _pointerY = value;
 }
 
-void InputManager::_updatePointerPosition(const PointerEvent evt)
+void InputManager::_updatePointerPosition(const PointerEvent& evt)
 {
   auto canvasRect = _scene->getEngine()->getRenderingCanvasClientRect();
 

--- a/src/BabylonCpp/src/layers/layer_scene_component.cpp
+++ b/src/BabylonCpp/src/layers/layer_scene_component.cpp
@@ -107,10 +107,8 @@ bool LayerSceneComponent::_drawRenderTargetPredicate(
   const Layer& layer, bool isBackground, unsigned int cameraLayerMask,
   const RenderTargetTexturePtr& renderTargetTexture) const
 {
-  return (layer.renderTargetTextures.size() > 0)
-         && layer.isBackground == isBackground
-         && (stl_util::index_of(layer.renderTargetTextures, renderTargetTexture)
-             > -1)
+  return (!layer.renderTargetTextures.empty()) && layer.isBackground == isBackground
+         && (stl_util::index_of(layer.renderTargetTextures, renderTargetTexture) > -1)
          && ((layer.layerMask & cameraLayerMask) != 0);
 }
 

--- a/src/BabylonCpp/src/lensflares/lens_flare_system.cpp
+++ b/src/BabylonCpp/src/lensflares/lens_flare_system.cpp
@@ -24,10 +24,10 @@
 
 namespace BABYLON {
 
-LensFlareSystem::LensFlareSystem(const std::string iName,
+LensFlareSystem::LensFlareSystem(const std::string& name,
                                  const LensFlareEmitterType& emitter,
                                  Scene* scene)
-    : name{iName}
+    : name{name}
     , borderLimit{300}
     , viewportBorder{0.f}
     , layerMask{0x0FFFFFFF}
@@ -46,7 +46,7 @@ LensFlareSystem::LensFlareSystem(const std::string iName,
   }
 
   _emitter = emitter;
-  id       = iName;
+  id       = name;
 
   meshesSelectionPredicate = [this](const AbstractMeshPtr& m) {
     return _scene->activeCamera() && m->material() && m->isVisible

--- a/src/BabylonCpp/src/lights/light.cpp
+++ b/src/BabylonCpp/src/lights/light.cpp
@@ -292,7 +292,7 @@ bool Light::canAffectMesh(AbstractMesh* mesh)
                    [mesh](const AbstractMeshPtr& includedOnlyMesh) {
                      return includedOnlyMesh.get() == mesh;
                    });
-  if (_includedOnlyMeshes.size() > 0 && it1 == _includedOnlyMeshes.end()) {
+  if (!_includedOnlyMeshes.empty() && it1 == _includedOnlyMeshes.end()) {
     return false;
   }
 
@@ -300,7 +300,7 @@ bool Light::canAffectMesh(AbstractMesh* mesh)
                           [mesh](const AbstractMeshPtr& excludedMesh) {
                             return excludedMesh.get() == mesh;
                           });
-  if (_excludedMeshes.size() > 0 && it2 != _excludedMeshes.end()) {
+  if (!_excludedMeshes.empty() && it2 != _excludedMeshes.end()) {
     return false;
   }
 

--- a/src/BabylonCpp/src/materials/background/background_material.cpp
+++ b/src/BabylonCpp/src/materials/background/background_material.cpp
@@ -640,7 +640,7 @@ bool BackgroundMaterial::isReadyForSubMesh(AbstractMesh* mesh,
   auto scene      = getScene();
   auto definesPtr = std::static_pointer_cast<BackgroundMaterialDefines>(
     subMesh->_materialDefines);
-  auto& defines = *definesPtr.get();
+  auto& defines = *definesPtr;
   if (!checkReadyOnEveryCall && subMesh->effect()) {
     if (defines._renderId == scene->getRenderId()) {
       return true;

--- a/src/BabylonCpp/src/materials/material_helper.cpp
+++ b/src/BabylonCpp/src/materials/material_helper.cpp
@@ -33,13 +33,13 @@ Color3 MaterialHelper::_tempFogColor = Color3::Black();
 void MaterialHelper::BindEyePosition(const EffectPtr& effect, Scene* scene)
 {
   if (scene->_forcedViewPosition) {
-    effect->setVector3("vEyePosition", *scene->_forcedViewPosition.get());
+    effect->setVector3("vEyePosition", *scene->_forcedViewPosition);
     return;
   }
   const auto& globalPosition = scene->activeCamera()->globalPosition();
 
   effect->setVector3("vEyePosition", scene->_mirroredCameraPosition ?
-                                       *scene->_mirroredCameraPosition.get() :
+                                       *scene->_mirroredCameraPosition :
                                        globalPosition);
 }
 

--- a/src/BabylonCpp/src/materials/multi_material.cpp
+++ b/src/BabylonCpp/src/materials/multi_material.cpp
@@ -7,8 +7,8 @@
 
 namespace BABYLON {
 
-MultiMaterial::MultiMaterial(const std::string iName, Scene* scene)
-    : Material{iName, scene, true}
+MultiMaterial::MultiMaterial(const std::string& name, Scene* scene)
+    : Material{name, scene, true}
     , subMaterials{this, &MultiMaterial::get_subMaterials,
                    &MultiMaterial::set_subMaterials}
 {

--- a/src/BabylonCpp/src/materials/node/blocks/add_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/add_block.cpp
@@ -20,9 +20,7 @@ AddBlock::AddBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-AddBlock::~AddBlock()
-{
-}
+AddBlock::~AddBlock() = default;
 
 std::string AddBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/clamp_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/clamp_block.cpp
@@ -18,9 +18,7 @@ ClampBlock::ClampBlock(const std::string& iName)
   registerOutput("output", NodeMaterialBlockConnectionPointTypes::Float);
 }
 
-ClampBlock::~ClampBlock()
-{
-}
+ClampBlock::~ClampBlock() = default;
 
 std::string ClampBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/color_merger_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/color_merger_block.cpp
@@ -24,9 +24,7 @@ ColorMergerBlock::ColorMergerBlock(const std::string& iName)
   registerOutput("rgb", NodeMaterialBlockConnectionPointTypes::Color3);
 }
 
-ColorMergerBlock::~ColorMergerBlock()
-{
-}
+ColorMergerBlock::~ColorMergerBlock() = default;
 
 std::string ColorMergerBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/color_splitter_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/color_splitter_block.cpp
@@ -26,9 +26,7 @@ ColorSplitterBlock::ColorSplitterBlock(const std::string& iName)
   registerOutput("a", NodeMaterialBlockConnectionPointTypes::Float);
 }
 
-ColorSplitterBlock::~ColorSplitterBlock()
-{
-}
+ColorSplitterBlock::~ColorSplitterBlock() = default;
 
 std::string ColorSplitterBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/cross_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/cross_block.cpp
@@ -20,9 +20,7 @@ CrossBlock::CrossBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-CrossBlock::~CrossBlock()
-{
-}
+CrossBlock::~CrossBlock() = default;
 
 std::string CrossBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/divide_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/divide_block.cpp
@@ -20,9 +20,7 @@ DivideBlock::DivideBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-DivideBlock::~DivideBlock()
-{
-}
+DivideBlock::~DivideBlock() = default;
 
 std::string DivideBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/dot_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/dot_block.cpp
@@ -19,9 +19,7 @@ DotBlock::DotBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-DotBlock::~DotBlock()
-{
-}
+DotBlock::~DotBlock() = default;
 
 std::string DotBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/dual/fog_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/dual/fog_block.cpp
@@ -44,9 +44,7 @@ FogBlock::FogBlock(const std::string& iName)
     NodeMaterialBlockConnectionPointTypes::Color4);
 }
 
-FogBlock::~FogBlock()
-{
-}
+FogBlock::~FogBlock() = default;
 
 std::string FogBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/dual/light_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/dual/light_block.cpp
@@ -37,9 +37,7 @@ LightBlock::LightBlock(const std::string& iName)
                  NodeMaterialBlockTargets::Fragment);
 }
 
-LightBlock::~LightBlock()
-{
-}
+LightBlock::~LightBlock() = default;
 
 std::string LightBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/dual/reflection_texture_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/dual/reflection_texture_block.cpp
@@ -51,9 +51,7 @@ ReflectionTextureBlock::ReflectionTextureBlock(const std::string& iName)
                  NodeMaterialBlockTargets::Fragment);
 }
 
-ReflectionTextureBlock::~ReflectionTextureBlock()
-{
-}
+ReflectionTextureBlock::~ReflectionTextureBlock() = default;
 
 std::string ReflectionTextureBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/dual/reflection_texture_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/dual/reflection_texture_block.cpp
@@ -114,7 +114,7 @@ void ReflectionTextureBlock::autoConfigure(const NodeMaterialPtr& material)
 {
   if (!position()->isConnected()) {
     auto positionInput = material->getInputBlockByPredicate(
-      [](const InputBlockPtr& b) -> bool { return b->isAttribute() && b->name == "position"; });
+      [](const InputBlockPtr& inputBlock) -> bool { return inputBlock->isAttribute() && inputBlock->name == "position"; });
 
     if (!positionInput) {
       positionInput = InputBlock::New("position");
@@ -124,8 +124,8 @@ void ReflectionTextureBlock::autoConfigure(const NodeMaterialPtr& material)
   }
 
   if (!world()->isConnected()) {
-    auto worldInput = material->getInputBlockByPredicate([](const InputBlockPtr& b) -> bool {
-      return b->systemValue() == NodeMaterialSystemValues::World;
+    auto worldInput = material->getInputBlockByPredicate([](const InputBlockPtr& inputBlock) -> bool {
+      return inputBlock->systemValue() == NodeMaterialSystemValues::World;
     });
 
     if (!worldInput) {
@@ -137,8 +137,8 @@ void ReflectionTextureBlock::autoConfigure(const NodeMaterialPtr& material)
 
   if (!cameraPosition()->isConnected()) {
     auto cameraPositionInput
-      = material->getInputBlockByPredicate([](const InputBlockPtr& b) -> bool {
-          return b->systemValue() == NodeMaterialSystemValues::CameraPosition;
+      = material->getInputBlockByPredicate([](const InputBlockPtr& inputBlock) -> bool {
+          return inputBlock->systemValue() == NodeMaterialSystemValues::CameraPosition;
         });
 
     if (!cameraPositionInput) {
@@ -149,8 +149,8 @@ void ReflectionTextureBlock::autoConfigure(const NodeMaterialPtr& material)
   }
 
   if (!view()->isConnected()) {
-    auto viewInput = material->getInputBlockByPredicate([](const InputBlockPtr& b) -> bool {
-      return b->systemValue() == NodeMaterialSystemValues::View;
+    auto viewInput = material->getInputBlockByPredicate([](const InputBlockPtr& inputBlock) -> bool {
+      return inputBlock->systemValue() == NodeMaterialSystemValues::View;
     });
 
     if (!viewInput) {

--- a/src/BabylonCpp/src/materials/node/blocks/dual/texture_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/dual/texture_block.cpp
@@ -48,9 +48,7 @@ TextureBlock::TextureBlock(const std::string& iName)
     NodeMaterialBlockConnectionPointTypes::Vector4);
 }
 
-TextureBlock::~TextureBlock()
-{
-}
+TextureBlock::~TextureBlock() = default;
 
 std::string TextureBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/dual/texture_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/dual/texture_block.cpp
@@ -141,7 +141,7 @@ void TextureBlock::autoConfigure(const NodeMaterialPtr& material)
 {
   if (!uv()->isConnected()) {
     auto uvInput = material->getInputBlockByPredicate(
-      [](const InputBlockPtr& b) -> bool { return b->isAttribute() && b->name == "uv"; });
+      [](const InputBlockPtr& inputBlock) -> bool { return inputBlock->isAttribute() && inputBlock->name == "uv"; });
 
     if (!uvInput) {
       uvInput = InputBlock::New("uv");

--- a/src/BabylonCpp/src/materials/node/blocks/fragment/alpha_test_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/fragment/alpha_test_block.cpp
@@ -18,9 +18,7 @@ AlphaTestBlock::AlphaTestBlock(const std::string& iName)
   registerInput("alpha", NodeMaterialBlockConnectionPointTypes::Float, true);
 }
 
-AlphaTestBlock::~AlphaTestBlock()
-{
-}
+AlphaTestBlock::~AlphaTestBlock() = default;
 
 std::string AlphaTestBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/fragment/fragment_output_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/fragment/fragment_output_block.cpp
@@ -19,9 +19,7 @@ FragmentOutputBlock::FragmentOutputBlock(const std::string& iName)
   registerInput("a", NodeMaterialBlockConnectionPointTypes::Float, true);
 }
 
-FragmentOutputBlock::~FragmentOutputBlock()
-{
-}
+FragmentOutputBlock::~FragmentOutputBlock() = default;
 
 std::string FragmentOutputBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/fragment/image_processing_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/fragment/image_processing_block.cpp
@@ -23,9 +23,7 @@ ImageProcessingBlock::ImageProcessingBlock(const std::string& iName)
     NodeMaterialBlockConnectionPointTypes::Color3);
 }
 
-ImageProcessingBlock::~ImageProcessingBlock()
-{
-}
+ImageProcessingBlock::~ImageProcessingBlock() = default;
 
 std::string ImageProcessingBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/fragment/perturb_normal_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/fragment/perturb_normal_block.cpp
@@ -34,9 +34,7 @@ PerturbNormalBlock::PerturbNormalBlock(const std::string& iName)
   registerOutput("output", NodeMaterialBlockConnectionPointTypes::Vector4);
 }
 
-PerturbNormalBlock::~PerturbNormalBlock()
-{
-}
+PerturbNormalBlock::~PerturbNormalBlock() = default;
 
 std::string PerturbNormalBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/fresnel_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/fresnel_block.cpp
@@ -23,9 +23,7 @@ FresnelBlock::FresnelBlock(const std::string& iName)
   registerOutput("fresnel", NodeMaterialBlockConnectionPointTypes::Float);
 }
 
-FresnelBlock::~FresnelBlock()
-{
-}
+FresnelBlock::~FresnelBlock() = default;
 
 std::string FresnelBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/input/input_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/input/input_block.cpp
@@ -44,9 +44,7 @@ InputBlock::InputBlock(const std::string& iName, NodeMaterialBlockTargets iTarge
   registerOutput("output", type);
 }
 
-InputBlock::~InputBlock()
-{
-}
+InputBlock::~InputBlock() = default;
 
 NodeMaterialBlockConnectionPointTypes& InputBlock::get_type()
 {

--- a/src/BabylonCpp/src/materials/node/blocks/input/input_value.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/input/input_value.cpp
@@ -28,9 +28,7 @@ InputValue& InputValue::operator=(InputValue&& other)
   return *this;
 }
 
-InputValue::~InputValue()
-{
-}
+InputValue::~InputValue() = default;
 
 InputValue InputValue::copy() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/input/input_value.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/input/input_value.cpp
@@ -6,13 +6,9 @@ InputValue::InputValue() : _value{std::nullopt}
 {
 }
 
-InputValue::InputValue(const InputValue& other) : _value{other._value}
-{
-}
+InputValue::InputValue(const InputValue& other) = default;
 
-InputValue::InputValue(InputValue&& other) : _value{std::move(other._value)}
-{
-}
+InputValue::InputValue(InputValue&& other) = default;
 
 InputValue& InputValue::operator=(const InputValue& other)
 {

--- a/src/BabylonCpp/src/materials/node/blocks/lerp_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/lerp_block.cpp
@@ -22,9 +22,7 @@ LerpBlock::LerpBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-LerpBlock::~LerpBlock()
-{
-}
+LerpBlock::~LerpBlock() =  default;
 
 std::string LerpBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/max_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/max_block.cpp
@@ -20,9 +20,7 @@ MaxBlock::MaxBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-MaxBlock::~MaxBlock()
-{
-}
+MaxBlock::~MaxBlock() = default;
 
 std::string MaxBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/min_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/min_block.cpp
@@ -20,9 +20,7 @@ MinBlock::MinBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-MinBlock::~MinBlock()
-{
-}
+MinBlock::~MinBlock() = default;
 
 std::string MinBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/multiply_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/multiply_block.cpp
@@ -20,9 +20,7 @@ MultiplyBlock::MultiplyBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-MultiplyBlock::~MultiplyBlock()
-{
-}
+MultiplyBlock::~MultiplyBlock() =  default;
 
 std::string MultiplyBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/normalize_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/normalize_block.cpp
@@ -17,9 +17,7 @@ NormalizeBlock::NormalizeBlock(const std::string& iName)
   _outputs[0]->_typeConnectionSource = _inputs[0];
 }
 
-NormalizeBlock::~NormalizeBlock()
-{
-}
+NormalizeBlock::~NormalizeBlock() =  default;
 
 std::string NormalizeBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/opposite_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/opposite_block.cpp
@@ -17,9 +17,7 @@ OppositeBlock::OppositeBlock(const std::string& iName)
   _outputs[0]->_typeConnectionSource = _inputs[0];
 }
 
-OppositeBlock::~OppositeBlock()
-{
-}
+OppositeBlock::~OppositeBlock() = default;
 
 std::string OppositeBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/remap_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/remap_block.cpp
@@ -20,9 +20,7 @@ RemapBlock::RemapBlock(const std::string& iName)
   _outputs[0]->_typeConnectionSource = _inputs[0];
 }
 
-RemapBlock::~RemapBlock()
-{
-}
+RemapBlock::~RemapBlock() = default;
 
 std::string RemapBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/scale_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/scale_block.cpp
@@ -19,9 +19,7 @@ ScaleBlock::ScaleBlock(const std::string& iName)
   _outputs[0]->_typeConnectionSource = _inputs[0];
 }
 
-ScaleBlock::~ScaleBlock()
-{
-}
+ScaleBlock::~ScaleBlock() = default;
 
 std::string ScaleBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/step_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/step_block.cpp
@@ -17,9 +17,7 @@ StepBlock::StepBlock(const std::string& iName)
   registerOutput("output", NodeMaterialBlockConnectionPointTypes::Float);
 }
 
-StepBlock::~StepBlock()
-{
-}
+StepBlock::~StepBlock() = default;
 
 std::string StepBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/subtract_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/subtract_block.cpp
@@ -20,9 +20,7 @@ SubtractBlock::SubtractBlock(const std::string& iName)
   _linkConnectionTypes(0, 1);
 }
 
-SubtractBlock::~SubtractBlock()
-{
-}
+SubtractBlock::~SubtractBlock() = default;
 
 std::string SubtractBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/transform_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/transform_block.cpp
@@ -20,9 +20,7 @@ TransformBlock::TransformBlock(const std::string& iName)
   registerOutput("output", NodeMaterialBlockConnectionPointTypes::Vector4);
 }
 
-TransformBlock::~TransformBlock()
-{
-}
+TransformBlock::~TransformBlock() = default;
 
 std::string TransformBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/trigonometry_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/trigonometry_block.cpp
@@ -17,9 +17,7 @@ TrigonometryBlock::TrigonometryBlock(const std::string& iName)
   registerInput("output", NodeMaterialBlockConnectionPointTypes::Float);
 }
 
-TrigonometryBlock::~TrigonometryBlock()
-{
-}
+TrigonometryBlock::~TrigonometryBlock() = default;
 
 std::string TrigonometryBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/vector_merger_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/vector_merger_block.cpp
@@ -26,9 +26,7 @@ VectorMergerBlock::VectorMergerBlock(const std::string& iName)
   registerOutput("xy", NodeMaterialBlockConnectionPointTypes::Vector2);
 }
 
-VectorMergerBlock::~VectorMergerBlock()
-{
-}
+VectorMergerBlock::~VectorMergerBlock() = default;
 
 std::string VectorMergerBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/vector_splitter_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/vector_splitter_block.cpp
@@ -30,9 +30,7 @@ VectorSplitterBlock::VectorSplitterBlock(const std::string& iName)
   registerOutput("w", NodeMaterialBlockConnectionPointTypes::Float);
 }
 
-VectorSplitterBlock::~VectorSplitterBlock()
-{
-}
+VectorSplitterBlock::~VectorSplitterBlock() = default;
 
 std::string VectorSplitterBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/vertex/bones_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/vertex/bones_block.cpp
@@ -32,9 +32,7 @@ BonesBlock::BonesBlock(const std::string& iName)
   registerOutput("output", NodeMaterialBlockConnectionPointTypes::Matrix);
 }
 
-BonesBlock::~BonesBlock()
-{
-}
+BonesBlock::~BonesBlock() = default;
 
 void BonesBlock::initialize(NodeMaterialBuildState& state)
 {

--- a/src/BabylonCpp/src/materials/node/blocks/vertex/instances_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/vertex/instances_block.cpp
@@ -28,9 +28,7 @@ InstancesBlock::InstancesBlock(const std::string& iName)
   registerOutput("output", NodeMaterialBlockConnectionPointTypes::Matrix);
 }
 
-InstancesBlock::~InstancesBlock()
-{
-}
+InstancesBlock::~InstancesBlock() = default;
 
 std::string InstancesBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/vertex/light_information_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/vertex/light_information_block.cpp
@@ -22,9 +22,7 @@ LightInformationBlock::LightInformationBlock(const std::string& iName)
   registerOutput("color", NodeMaterialBlockConnectionPointTypes::Color3);
 }
 
-LightInformationBlock::~LightInformationBlock()
-{
-}
+LightInformationBlock::~LightInformationBlock() = default;
 
 std::string LightInformationBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/vertex/morph_targets_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/vertex/morph_targets_block.cpp
@@ -37,9 +37,7 @@ MorphTargetsBlock::MorphTargetsBlock(const std::string& iName)
   registerOutput("uvOutput", NodeMaterialBlockConnectionPointTypes::Vector2);
 }
 
-MorphTargetsBlock::~MorphTargetsBlock()
-{
-}
+MorphTargetsBlock::~MorphTargetsBlock() = default;
 
 std::string MorphTargetsBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/vertex/vertex_output_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/vertex/vertex_output_block.cpp
@@ -12,9 +12,7 @@ VertexOutputBlock::VertexOutputBlock(const std::string& iName)
 {
 }
 
-VertexOutputBlock::~VertexOutputBlock()
-{
-}
+VertexOutputBlock::~VertexOutputBlock() = default;
 
 std::string VertexOutputBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/blocks/view_direction_block.cpp
+++ b/src/BabylonCpp/src/materials/node/blocks/view_direction_block.cpp
@@ -21,9 +21,7 @@ ViewDirectionBlock::ViewDirectionBlock(const std::string& iName)
   registerOutput("output", NodeMaterialBlockConnectionPointTypes::Vector3);
 }
 
-ViewDirectionBlock::~ViewDirectionBlock()
-{
-}
+ViewDirectionBlock::~ViewDirectionBlock() = default;
 
 std::string ViewDirectionBlock::getClassName() const
 {

--- a/src/BabylonCpp/src/materials/node/node_material.cpp
+++ b/src/BabylonCpp/src/materials/node/node_material.cpp
@@ -54,9 +54,7 @@ NodeMaterial::NodeMaterial(const std::string& iName, Scene* iScene,
   _attachImageProcessingConfiguration(nullptr);
 }
 
-NodeMaterial::~NodeMaterial()
-{
-}
+NodeMaterial::~NodeMaterial() = default;
 
 INodeMaterialOptionsPtr& NodeMaterial::get_options()
 {

--- a/src/BabylonCpp/src/materials/node/node_material_block.cpp
+++ b/src/BabylonCpp/src/materials/node/node_material_block.cpp
@@ -31,9 +31,7 @@ NodeMaterialBlock::NodeMaterialBlock(const std::string& iName, NodeMaterialBlock
   uniqueId       = UniqueIdGenerator::UniqueId();
 }
 
-NodeMaterialBlock::~NodeMaterialBlock()
-{
-}
+NodeMaterialBlock::~NodeMaterialBlock() = default;
 
 bool NodeMaterialBlock::get_isFinalMerger() const
 {

--- a/src/BabylonCpp/src/materials/node/node_material_build_state_shared_data.cpp
+++ b/src/BabylonCpp/src/materials/node/node_material_build_state_shared_data.cpp
@@ -42,9 +42,7 @@ NodeMaterialBuildStateSharedData::NodeMaterialBuildStateSharedData()
   defineNames["MAINUV7"] = 0;
 }
 
-NodeMaterialBuildStateSharedData::~NodeMaterialBuildStateSharedData()
-{
-}
+NodeMaterialBuildStateSharedData::~NodeMaterialBuildStateSharedData() = default;
 
 void NodeMaterialBuildStateSharedData::emitErrors()
 {

--- a/src/BabylonCpp/src/materials/node/node_material_connection_point.cpp
+++ b/src/BabylonCpp/src/materials/node/node_material_connection_point.cpp
@@ -151,7 +151,7 @@ std::vector<NodeMaterialConnectionPointPtr>& NodeMaterialConnectionPoint::get_en
 
 bool NodeMaterialConnectionPoint::get_hasEndpoints() const
 {
-  return _endpoints.size() > 0;
+  return !_endpoints.empty();
 }
 
 std::string NodeMaterialConnectionPoint::getClassName() const

--- a/src/BabylonCpp/src/materials/node/node_material_defines.cpp
+++ b/src/BabylonCpp/src/materials/node/node_material_defines.cpp
@@ -44,9 +44,7 @@ NodeMaterialDefines::NodeMaterialDefines() : MaterialDefines{}
   };
 }
 
-NodeMaterialDefines::~NodeMaterialDefines()
-{
-}
+NodeMaterialDefines::~NodeMaterialDefines() = default;
 
 void NodeMaterialDefines::setValue(const std::string& name, bool value)
 {

--- a/src/BabylonCpp/src/materials/pbr/pbr_base_material.cpp
+++ b/src/BabylonCpp/src/materials/pbr/pbr_base_material.cpp
@@ -1543,39 +1543,38 @@ std::vector<IAnimatablePtr> PBRBaseMaterial::getAnimatables()
 {
   std::vector<IAnimatablePtr> results;
 
-  if (_albedoTexture && _albedoTexture->animations.size() > 0) {
+  if (_albedoTexture && !_albedoTexture->animations.empty()) {
     results.emplace_back(_albedoTexture);
   }
 
-  if (_ambientTexture && _ambientTexture->animations.size() > 0) {
+  if (_ambientTexture && !_ambientTexture->animations.empty()) {
     results.emplace_back(_ambientTexture);
   }
 
-  if (_opacityTexture && _opacityTexture->animations.size() > 0) {
+  if (_opacityTexture && !_opacityTexture->animations.empty()) {
     results.emplace_back(_opacityTexture);
   }
 
-  if (_reflectionTexture && _reflectionTexture->animations.size() > 0) {
+  if (_reflectionTexture && !_reflectionTexture->animations.empty()) {
     results.emplace_back(_reflectionTexture);
   }
 
-  if (_emissiveTexture && _emissiveTexture->animations.size() > 0) {
+  if (_emissiveTexture && !_emissiveTexture->animations.empty()) {
     results.emplace_back(_emissiveTexture);
   }
 
-  if (_metallicTexture && _metallicTexture->animations.size() > 0) {
+  if (_metallicTexture && !_metallicTexture->animations.empty()) {
     results.emplace_back(_metallicTexture);
   }
-  else if (_reflectivityTexture
-           && _reflectivityTexture->animations.size() > 0) {
+  else if (_reflectivityTexture && !_reflectivityTexture->animations.empty()) {
     results.emplace_back(_reflectivityTexture);
   }
 
-  if (_bumpTexture && _bumpTexture->animations.size() > 0) {
+  if (_bumpTexture && !_bumpTexture->animations.empty()) {
     results.emplace_back(_bumpTexture);
   }
 
-  if (_lightmapTexture && _lightmapTexture->animations.size() > 0) {
+  if (_lightmapTexture && !_lightmapTexture->animations.empty()) {
     results.emplace_back(_lightmapTexture);
   }
 

--- a/src/BabylonCpp/src/materials/pbr/pbr_base_material.cpp
+++ b/src/BabylonCpp/src/materials/pbr/pbr_base_material.cpp
@@ -308,7 +308,7 @@ bool PBRBaseMaterial::isReadyForSubMesh(AbstractMesh* mesh,
   auto scene = getScene();
   auto definesPtr
     = std::static_pointer_cast<PBRMaterialDefines>(subMesh->_materialDefines);
-  auto& defines = *definesPtr.get();
+  auto& defines = *definesPtr;
   if (!checkReadyOnEveryCall && subMesh->effect()) {
     if (defines._renderId == scene->getRenderId()) {
       return true;

--- a/src/BabylonCpp/src/materials/standard_material.cpp
+++ b/src/BabylonCpp/src/materials/standard_material.cpp
@@ -498,7 +498,7 @@ bool StandardMaterial::isReadyForSubMesh(AbstractMesh* mesh,
   auto scene      = getScene();
   auto definesPtr = std::static_pointer_cast<StandardMaterialDefines>(
     subMesh->_materialDefines);
-  auto& defines = *definesPtr.get();
+  auto& defines = *definesPtr;
   if (!checkReadyOnEveryCall && subMesh->effect()) {
     if (defines._renderId == scene->getRenderId()) {
       return true;

--- a/src/BabylonCpp/src/materials/standard_material.cpp
+++ b/src/BabylonCpp/src/materials/standard_material.cpp
@@ -1397,39 +1397,39 @@ std::vector<IAnimatablePtr> StandardMaterial::getAnimatables()
 {
   std::vector<IAnimatablePtr> results;
 
-  if (_diffuseTexture && _diffuseTexture->animations.size() > 0) {
+  if (_diffuseTexture && !_diffuseTexture->animations.empty()) {
     results.emplace_back(_diffuseTexture);
   }
 
-  if (_ambientTexture && _ambientTexture->animations.size() > 0) {
+  if (_ambientTexture && !_ambientTexture->animations.empty()) {
     results.emplace_back(_ambientTexture);
   }
 
-  if (_opacityTexture && _opacityTexture->animations.size() > 0) {
+  if (_opacityTexture && !_opacityTexture->animations.empty()) {
     results.emplace_back(_opacityTexture);
   }
 
-  if (_reflectionTexture && _reflectionTexture->animations.size() > 0) {
+  if (_reflectionTexture && !_reflectionTexture->animations.empty()) {
     results.emplace_back(_reflectionTexture);
   }
 
-  if (_emissiveTexture && _emissiveTexture->animations.size() > 0) {
+  if (_emissiveTexture && !_emissiveTexture->animations.empty()) {
     results.emplace_back(_emissiveTexture);
   }
 
-  if (_specularTexture && _specularTexture->animations.size() > 0) {
+  if (_specularTexture && !_specularTexture->animations.empty()) {
     results.emplace_back(_specularTexture);
   }
 
-  if (_bumpTexture && _bumpTexture->animations.size() > 0) {
+  if (_bumpTexture && !_bumpTexture->animations.empty()) {
     results.emplace_back(_bumpTexture);
   }
 
-  if (_lightmapTexture && _lightmapTexture->animations.size() > 0) {
+  if (_lightmapTexture && !_lightmapTexture->animations.empty()) {
     results.emplace_back(_lightmapTexture);
   }
 
-  if (_refractionTexture && _refractionTexture->animations.size() > 0) {
+  if (_refractionTexture && !_refractionTexture->animations.empty()) {
     results.emplace_back(_refractionTexture);
   }
 

--- a/src/BabylonCpp/src/materials/textures/internal_texture.cpp
+++ b/src/BabylonCpp/src/materials/textures/internal_texture.cpp
@@ -12,20 +12,6 @@
 
 namespace BABYLON {
 
-constexpr unsigned int InternalTexture::DATASOURCE_UNKNOWN;
-constexpr unsigned int InternalTexture::DATASOURCE_URL;
-constexpr unsigned int InternalTexture::DATASOURCE_TEMP;
-constexpr unsigned int InternalTexture::DATASOURCE_RAW;
-constexpr unsigned int InternalTexture::DATASOURCE_DYNAMIC;
-constexpr unsigned int InternalTexture::DATASOURCE_RENDERTARGET;
-constexpr unsigned int InternalTexture::DATASOURCE_MULTIRENDERTARGET;
-constexpr unsigned int InternalTexture::DATASOURCE_CUBE;
-constexpr unsigned int InternalTexture::DATASOURCE_CUBERAW;
-constexpr unsigned int InternalTexture::DATASOURCE_CUBEPREFILTERED;
-constexpr unsigned int InternalTexture::DATASOURCE_RAW3D;
-constexpr unsigned int InternalTexture::DATASOURCE_DEPTHTEXTURE;
-constexpr unsigned int InternalTexture::DATASOURCE_CUBERAW_RGBD;
-
 InternalTexture::InternalTexture(Engine* engine, unsigned int dataSource,
                                  bool delayAllocation)
     : isReady{false}

--- a/src/BabylonCpp/src/materials/textures/procedurals/procedural_texture_scene_component.cpp
+++ b/src/BabylonCpp/src/materials/textures/procedurals/procedural_texture_scene_component.cpp
@@ -34,15 +34,13 @@ void ProceduralTextureSceneComponent::dispose()
 void ProceduralTextureSceneComponent::_beforeClear()
 {
   if (scene->proceduralTexturesEnabled) {
-    Tools::StartPerformanceCounter("Procedural textures",
-                                   scene->proceduralTextures.size() > 0);
+    Tools::StartPerformanceCounter("Procedural textures", !scene->proceduralTextures.empty());
     for (const auto& proceduralTexture : scene->proceduralTextures) {
       if (proceduralTexture->_shouldRender()) {
         proceduralTexture->render();
       }
     }
-    Tools::EndPerformanceCounter("Procedural textures",
-                                 scene->proceduralTextures.size() > 0);
+    Tools::EndPerformanceCounter("Procedural textures", !scene->proceduralTextures.empty());
   }
 }
 

--- a/src/BabylonCpp/src/materials/textures/texture_constants.cpp
+++ b/src/BabylonCpp/src/materials/textures/texture_constants.cpp
@@ -1,9 +1,0 @@
-#include <babylon/materials/textures/texture_constants.h>
-
-namespace BABYLON {
-
-constexpr unsigned int TextureConstants::NEAREST_SAMPLINGMODE;
-constexpr unsigned int TextureConstants::BILINEAR_SAMPLINGMODE;
-constexpr unsigned int TextureConstants::TRILINEAR_SAMPLINGMODE;
-
-} // end of namespace BABYLON

--- a/src/BabylonCpp/src/maths/curve3.cpp
+++ b/src/BabylonCpp/src/maths/curve3.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<Curve3> Curve3::clone() const
 std::ostream& operator<<(std::ostream& os, const Curve3& curve)
 {
   os << "{\"Points\":[";
-  if (curve._points.size() > 0) {
+  if (!curve._points.empty()) {
     for (unsigned int i = 0; i < curve._points.size() - 1; ++i) {
       os << curve._points[i] << ",";
     }

--- a/src/BabylonCpp/src/maths/path2.cpp
+++ b/src/BabylonCpp/src/maths/path2.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<Path2> Path2::clone() const
 std::ostream& operator<<(std::ostream& os, const Path2& path)
 {
   os << "{\"Points\":[";
-  if (path._points.size() > 0) {
+  if (!path._points.empty()) {
     for (unsigned int i = 0; i < path._points.size() - 1; ++i) {
       os << path._points[i] << ",";
     }

--- a/src/BabylonCpp/src/maths/path3d.cpp
+++ b/src/BabylonCpp/src/maths/path3d.cpp
@@ -39,35 +39,35 @@ std::ostream& operator<<(std::ostream& os, const Path3D& path)
 {
   os << "{\"Raw\":" << path._raw;
   os << ",\"Curve\":[";
-  if (path._curve.size() > 0) {
+  if (!path._curve.empty()) {
     for (unsigned int i = 0; i < path._curve.size() - 1; ++i) {
       os << path._curve[i] << ",";
     }
     os << path._curve.back();
   }
   os << "],\"Distances\":[";
-  if (path._distances.size() > 0) {
+  if (!path._distances.empty()) {
     for (unsigned int i = 0; i < path._distances.size() - 1; ++i) {
       os << path._distances[i] << ",";
     }
     os << path._distances.back();
   }
   os << "],\"Tangents\":[";
-  if (path._tangents.size() > 0) {
+  if (!path._tangents.empty()) {
     for (unsigned int i = 0; i < path._tangents.size() - 1; ++i) {
       os << path._tangents[i] << ",";
     }
     os << path._tangents.back();
   }
   os << "],\"Normals\":[";
-  if (path._normals.size() > 0) {
+  if (!path._normals.empty()) {
     for (unsigned int i = 0; i < path._normals.size() - 1; ++i) {
       os << path._normals[i] << ",";
     }
     os << path._normals.back();
   }
   os << "],\"Binormals\":[";
-  if (path._binormals.size() > 0) {
+  if (!path._binormals.empty()) {
     for (unsigned int i = 0; i < path._binormals.size() - 1; ++i) {
       os << path._binormals[i] << ",";
     }

--- a/src/BabylonCpp/src/meshes/csg/polygon.cpp
+++ b/src/BabylonCpp/src/meshes/csg/polygon.cpp
@@ -43,7 +43,7 @@ namespace CSG {
 std::ostream& operator<<(std::ostream& os, const Polygon& polygon)
 {
   os << "{\"Vertices\":[";
-  if (polygon.vertices.size() > 0) {
+  if (!polygon.vertices.empty()) {
     for (unsigned int i = 0; i < polygon.vertices.size() - 1; ++i) {
       os << polygon.vertices[i] << ",";
     }

--- a/src/BabylonCpp/src/meshes/geometry.cpp
+++ b/src/BabylonCpp/src/meshes/geometry.cpp
@@ -576,7 +576,7 @@ void Geometry::_applyToMesh(Mesh* mesh)
   }
 
   // indexBuffer
-  if (numOfMeshes == 1 && _indices.size() > 0) {
+  if (numOfMeshes == 1 && !_indices.empty()) {
     _indexBuffer = std::unique_ptr<GL::IGLBuffer>(_engine->createIndexBuffer(_indices));
   }
   if (_indexBuffer) {

--- a/src/BabylonCpp/src/meshes/mesh.cpp
+++ b/src/BabylonCpp/src/meshes/mesh.cpp
@@ -291,7 +291,7 @@ void Mesh::set_onBeforeDraw(const std::function<void(Mesh*, EventState&)>& callb
 
 bool Mesh::get_hasInstances() const
 {
-  return instances.size() > 0;
+  return !instances.empty();
 }
 
 std::string Mesh::toString(bool fullDetails)
@@ -340,7 +340,7 @@ void Mesh::_unBindEffect()
 
 bool Mesh::get_hasLODLevels() const
 {
-  return _internalMeshDataInfo->_LODLevels.size() > 0;
+  return !_internalMeshDataInfo->_LODLevels.empty();
 }
 
 std::vector<MeshLODLevelPtr>& Mesh::getLODLevels()
@@ -575,7 +575,7 @@ bool Mesh::isReady(bool completeCheck, bool forceInstanceSupport)
   auto engine = getEngine();
   auto scene  = getScene();
   auto hardwareInstancedRendering
-    = forceInstanceSupport || (engine->getCaps().instancedArrays && instances.size() > 0);
+    = forceInstanceSupport || (engine->getCaps().instancedArrays && !instances.empty());
 
   computeWorldMatrix();
 
@@ -944,7 +944,7 @@ void Mesh::_bind(SubMesh* subMesh, const EffectPtr& effect, unsigned int fillMod
 
 void Mesh::_draw(SubMesh* subMesh, int fillMode, size_t instancesCount, bool /*alternate*/)
 {
-  if (!_geometry || !_geometry->getVertexBuffers().size()
+  if (!_geometry || _geometry->getVertexBuffers().empty()
       || (!_unIndexed && !_geometry->getIndexBuffer())) {
     return;
   }

--- a/src/BabylonCpp/src/meshes/mesh.cpp
+++ b/src/BabylonCpp/src/meshes/mesh.cpp
@@ -1824,7 +1824,7 @@ void Mesh::dispose(bool doNotRecurse, bool disposeMaterialAndTextures)
 }
 
 Mesh& Mesh::applyDisplacementMap(const std::string& url, float minHeight, float maxHeight,
-                                 const std::function<void(Mesh* mesh)> onSuccess,
+                                 std::function<void(Mesh* mesh)> onSuccess,
                                  const std::optional<Vector2>& uvOffset,
                                  const std::optional<Vector2>& uvScale, bool forceUpdate)
 {
@@ -3499,7 +3499,7 @@ MeshPtr Mesh::MergeMeshes(const std::vector<MeshPtr>& meshes, bool disposeSource
       otherVertexData->transform(wm);
 
       if (vertexData) {
-        vertexData->merge(*otherVertexData.get(), allow32BitsIndices);
+        vertexData->merge(*otherVertexData, allow32BitsIndices);
       }
       else {
         vertexData = std::move(otherVertexData);

--- a/src/BabylonCpp/src/meshes/vertex_buffer.cpp
+++ b/src/BabylonCpp/src/meshes/vertex_buffer.cpp
@@ -7,50 +7,7 @@
 
 namespace BABYLON {
 
-constexpr const char* VertexBuffer::PositionKind;
-constexpr const char* VertexBuffer::NormalKind;
-constexpr const char* VertexBuffer::TangentKind;
-constexpr const char* VertexBuffer::UVKind;
-constexpr const char* VertexBuffer::UV2Kind;
-constexpr const char* VertexBuffer::UV3Kind;
-constexpr const char* VertexBuffer::UV4Kind;
-constexpr const char* VertexBuffer::UV5Kind;
-constexpr const char* VertexBuffer::UV6Kind;
-constexpr const char* VertexBuffer::ColorKind;
-constexpr const char* VertexBuffer::MatricesIndicesKind;
-constexpr const char* VertexBuffer::MatricesWeightsKind;
-constexpr const char* VertexBuffer::MatricesIndicesExtraKind;
-constexpr const char* VertexBuffer::MatricesWeightsExtraKind;
-constexpr const char* VertexBuffer::World0Kind;
-constexpr const char* VertexBuffer::World1Kind;
-constexpr const char* VertexBuffer::World2Kind;
-constexpr const char* VertexBuffer::World3Kind;
-constexpr const char* VertexBuffer::CellInfoKind;
-constexpr const char* VertexBuffer::OptionsKind;
-constexpr const char* VertexBuffer::AgeKind;
-constexpr const char* VertexBuffer::LifeKind;
-constexpr const char* VertexBuffer::VelocityKind;
-constexpr const char* VertexBuffer::DirectionKind;
-constexpr const char* VertexBuffer::InitialDirectionKind;
-constexpr const char* VertexBuffer::OffsetKind;
-constexpr const char* VertexBuffer::SeedKind;
-constexpr const char* VertexBuffer::SizeKind;
-constexpr const char* VertexBuffer::AngleKind;
-constexpr const char* VertexBuffer::CellStartOffsetKind;
-constexpr const char* VertexBuffer::NoiseCoordinates1Kind;
-constexpr const char* VertexBuffer::NoiseCoordinates2Kind;
-constexpr const char* VertexBuffer::RemapDataKind;
-constexpr const char* VertexBuffer::InvertsKind;
-
-constexpr const unsigned int VertexBuffer::BYTE;
-constexpr const unsigned int VertexBuffer::UNSIGNED_BYTE;
-constexpr const unsigned int VertexBuffer::SHORT;
-constexpr const unsigned int VertexBuffer::UNSIGNED_SHORT;
-constexpr const unsigned int VertexBuffer::INT;
-constexpr const unsigned int VertexBuffer::UNSIGNED_INT;
-constexpr const unsigned int VertexBuffer::FLOAT;
-
-VertexBuffer::VertexBuffer(Engine* engine, const std::variant<Float32Array, Buffer*> data,
+VertexBuffer::VertexBuffer(Engine* engine, const std::variant<Float32Array, Buffer*>& data,
                            const std::string& kind, bool updatable,
                            const std::optional<bool>& postponeInternalCreation,
                            std::optional<size_t> stride, const std::optional<bool>& instanced,

--- a/src/BabylonCpp/src/misc/optimization/merge_meshes_optimization.cpp
+++ b/src/BabylonCpp/src/misc/optimization/merge_meshes_optimization.cpp
@@ -45,7 +45,7 @@ bool MergeMeshesOptimization::_canBeMerged(const AbstractMeshPtr& abstractMesh)
     return false;
   }
 
-  if (mesh->instances.size() > 0) {
+  if (!mesh->instances.empty()) {
     return false;
   }
 

--- a/src/BabylonCpp/src/particles/base_particle_system.cpp
+++ b/src/BabylonCpp/src/particles/base_particle_system.cpp
@@ -139,8 +139,8 @@ void BaseParticleSystem::set_isAnimationSheetEnabled(bool value)
 
 bool BaseParticleSystem::_hasTargetStopDurationDependantGradient() const
 {
-  return (_startSizeGradients.size() > 0) || (_emitRateGradients.size() > 0)
-         || (_lifeTimeGradients.size() > 0);
+  return (!_startSizeGradients.empty()) || (!_emitRateGradients.empty())
+         || (!_lifeTimeGradients.empty());
 }
 
 std::vector<FactorGradient>& BaseParticleSystem::getDragGradients()

--- a/src/BabylonCpp/src/particles/particle_system.cpp
+++ b/src/BabylonCpp/src/particles/particle_system.cpp
@@ -164,7 +164,7 @@ ParticleSystem::ParticleSystem(const std::string& iName, size_t capacity,
       auto directionScale = scaledUpdateSpeed;
 
       // Velocity
-      if (_velocityGradients.size() > 0) {
+      if (!_velocityGradients.empty()) {
         GradientHelper::GetCurrentGradient<FactorGradient>(
           ratio, _velocityGradients,
           [&](FactorGradient& currentGradient, FactorGradient& nextGradient,
@@ -859,7 +859,7 @@ void ParticleSystem::start(size_t delay)
 
   // Reset emit gradient so it acts the same on every start
   if (!_emitRateGradients.empty()) {
-    if (_emitRateGradients.size() > 0) {
+    if (!_emitRateGradients.empty()) {
       _currentEmitRateGradient = _emitRateGradients[0];
       _currentEmitRate1        = _currentEmitRateGradient->getFactor();
       _currentEmitRate2        = _currentEmitRate1;
@@ -870,7 +870,7 @@ void ParticleSystem::start(size_t delay)
   }
   // Reset start size gradient so it acts the same on every start
   if (!_startSizeGradients.empty()) {
-    if (_startSizeGradients.size() > 0) {
+    if (!_startSizeGradients.empty()) {
       _currentStartSizeGradient = _startSizeGradients[0];
       _currentStartSize1        = _currentStartSizeGradient->getFactor();
       _currentStartSize2        = _currentStartSize1;

--- a/src/BabylonCpp/src/postprocesses/post_process.cpp
+++ b/src/BabylonCpp/src/postprocesses/post_process.cpp
@@ -495,7 +495,7 @@ void PostProcess::dispose(Camera* camera)
   pCamera->detachPostProcess(this);
 
   const auto index = stl_util::index_of_raw_ptr(pCamera->_postProcesses, this);
-  if (index == 0 && pCamera->_postProcesses.size() > 0) {
+  if (index == 0 && !pCamera->_postProcesses.empty()) {
     auto firstPostProcess = _camera->_getFirstPostProcess();
     if (firstPostProcess) {
       firstPostProcess->markTextureDirty();

--- a/src/BabylonCpp/tests/common/std_util_test.cpp
+++ b/src/BabylonCpp/tests/common/std_util_test.cpp
@@ -177,7 +177,7 @@ TEST(TestStdUtil, contains)
     auto numbersFiltered = std::vector<std::reference_wrapper<const int>>{};
     std::for_each(numbers.begin(), numbers.end(), [&numbersFiltered](auto& v) {
       if (*v > 5) {
-        numbersFiltered.emplace_back(std::ref(*v.get()));
+        numbersFiltered.emplace_back(std::ref(*v));
       }
     });
 

--- a/src/Loaders/src/loading/glTF/gltf_file_loader.cpp
+++ b/src/Loaders/src/loading/glTF/gltf_file_loader.cpp
@@ -542,7 +542,7 @@ std::optional<Version> GLTFFileLoader::_parseVersion(const std::string& version)
     };
   }
 
-  const std::regex regex(R"((\d+)\.(\d+))", std::regex::optimize);
+  static std::regex regex(R"((\d+)\.(\d+))", std::regex::optimize);
   auto match = String::regexMatch(version, regex);
   if (match.size() < 2) {
     return std::nullopt;


### PR DESCRIPTION
Hi,

Here are some warning corrections, when compiling BabylonCpp with clang-tidy.

The commits should be self explanatory. I only mention the important ones below:

#### clang: remove cmake clang related hacks:

See https://github.com/samdauwe/BabylonCpp/commit/03291233f363f329e63a45ed8fb44bb8d1ac8363

This code is not needed, and actually failed with clang 9.

#### Engine::GetExponentOfTwo

See https://github.com/samdauwe/BabylonCpp/commit/78a924ec861b616d1d33199031173d83d14b8cef : 

I added an exception inside Engine::GetExponentOfTwo because it handles only a part of the enum.

#### clang-tidy warnings inside babylon_common.h and any.h :

See https://github.com/samdauwe/BabylonCpp/commit/0b89698a73ad759874f91d61d409352b66b4055f

I added some `NOLINT` comments because these warnings would appear all the time. clang-tidy warns that 1) these `operator=`do not return `*this*`and 2) that they do not test for pointer equality.
Can you please have a look at them and make sure that we can silence them safely.

#### regex / performance warnings:

https://github.com/samdauwe/BabylonCpp/pull/62/commits/24d1024cd4529340f91f3e19d422c308a481f3f7

This was not given by clang-tidy, I stumbled upon it. It seems there are places where the std::regex should be made static for better performance.

------

I encourage you to test to compile with clang-tidy as the list of warning inside BabylonCpp is now reduced, and actually the warnings that I see is now very interesting and could point you to some hard to track bugs that are present in the code.
For example there are a lot of warnings about if/else branchs containing the same code, see [bugprone-branch-clone](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-branch-clone.html)
