### PR TITLE
Cmake refac

### DIFF
--- a/cmake/BabylonAddLibrary.cmake
+++ b/cmake/BabylonAddLibrary.cmake
@@ -40,3 +40,23 @@ function(babylon_add_executable TARGET)
     add_executable(${TARGET} ${ARGN})
     babylon_target_clang_tidy(${TARGET})
 endfunction()
+
+
+function(babylon_add_library_glob TARGET)
+    set(include_path "${CMAKE_CURRENT_SOURCE_DIR}/include/")
+    set(source_path  "${CMAKE_CURRENT_SOURCE_DIR}/src")
+    file(GLOB_RECURSE headers
+        ${include_path}/*.h
+        ${include_path}/*.hpp
+        )
+    file(GLOB_RECURSE sources
+        ${source_path}/*.cpp
+        ${source_path}/*.c
+        )
+    file(GLOB_RECURSE misc
+        ${CMAKE_CURRENT_SOURCE_DIR}/*.md
+        ${CMAKE_CURRENT_SOURCE_DIR}/*.txt
+        ${CMAKE_CURRENT_SOURCE_DIR}/*.json
+        )
+    babylon_add_library(${TARGET} ${sources} ${headers} ${misc})
+endfunction()

--- a/cmake/BabylonAddLibrary.cmake
+++ b/cmake/BabylonAddLibrary.cmake
@@ -1,0 +1,38 @@
+function(babylon_add_library TARGET)
+    message("babylon_add_library ${TARGET}")
+
+    add_library(${TARGET} ${ARGN})
+    babylon_target_clang_tidy(${TARGET})
+
+    # Create namespaced alias
+    add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
+
+    # Create API export header
+    generate_export_header(${TARGET}
+        EXPORT_FILE_NAME  ${EXPORT_FILE}
+        EXPORT_MACRO_NAME ${EXPORT_MACRO}
+        )
+
+    # Set library ouput name
+    set_target_properties(${TARGET}
+        PROPERTIES  PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
+        OUTPUT_NAME $<LOWER_CASE:${TARGET}>
+        VERSION ${META_VERSION}
+        SOVERSION ${META_VERSION}
+        )
+
+    # Compile definitions
+    target_compile_definitions(${TARGET}
+        PUBLIC
+        $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
+        )
+
+endfunction()
+
+
+function(babylon_add_executable TARGET)
+    message("babylon_add_executable ${TARGET}")
+
+    add_executable(${TARGET} ${ARGN})
+    babylon_target_clang_tidy(${TARGET})
+endfunction()

--- a/cmake/BabylonAddLibrary.cmake
+++ b/cmake/BabylonAddLibrary.cmake
@@ -27,6 +27,10 @@ function(babylon_add_library TARGET)
         $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
         )
 
+    # group sources
+    get_target_property(sources ${TARGET} SOURCES)
+    source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${sources})
+
 endfunction()
 
 

--- a/cmake/BabylonAddTest.cmake
+++ b/cmake/BabylonAddTest.cmake
@@ -6,4 +6,5 @@ macro(babylon_add_test TESTNAME)
 
     target_link_libraries(${TESTNAME} PRIVATE gtest gmock gtest_main)
     add_test(NAME ${TESTNAME} COMMAND ${TESTNAME})
+    babylon_target_clang_tidy(${TESTNAME})
 endmacro()

--- a/cmake/BabylonAddTest.cmake
+++ b/cmake/BabylonAddTest.cmake
@@ -7,4 +7,8 @@ macro(babylon_add_test TESTNAME)
     target_link_libraries(${TESTNAME} PRIVATE gtest gmock gtest_main)
     add_test(NAME ${TESTNAME} COMMAND ${TESTNAME})
     babylon_target_clang_tidy(${TESTNAME})
+
+    # group sources
+    get_target_property(sources ${TESTNAME} SOURCES)
+    source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${sources})
 endmacro()

--- a/cmake/BabylonAddTest.cmake
+++ b/cmake/BabylonAddTest.cmake
@@ -1,0 +1,9 @@
+macro(babylon_add_test TESTNAME)
+    message("babylon_add_test ${TESTNAME}")
+    add_executable(${TESTNAME} ${ARGN})
+    # Create namespaced alias
+    add_executable(${META_PROJECT_NAME}::${TESTNAME} ALIAS ${TESTNAME})
+
+    target_link_libraries(${TESTNAME} PRIVATE gtest gmock gtest_main)
+    add_test(NAME ${TESTNAME} COMMAND ${TESTNAME})
+endmacro()

--- a/cmake/BuildEnvironment.cmake
+++ b/cmake/BuildEnvironment.cmake
@@ -10,17 +10,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 # Include cmake modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-set(WriterCompilerDetectionHeaderFound NOTFOUND)
 
 include(GenerateExportHeader)
 include(ExternalProject)
 
-# This module is only available with CMake >=3.1, so check whether it could be found
-include(WriteCompilerDetectionHeader OPTIONAL RESULT_VARIABLE WriterCompilerDetectionHeaderFound)
-# BUT in CMake 3.1 this module doesn't recognize AppleClang as compiler, so disable it
-if (${CMAKE_VERSION} VERSION_LESS "3.2")
-    set(WriterCompilerDetectionHeaderFound NOTFOUND)
-endif()
+include(WriteCompilerDetectionHeader)
 
 # Git version
 include(${CMAKE_CURRENT_LIST_DIR}/GetGitRevisionDescription.cmake)

--- a/cmake/Custom.cmake
+++ b/cmake/Custom.cmake
@@ -10,32 +10,14 @@ function(set_policy POL VAL)
 endfunction(set_policy)
 
 
-# Define function "source_group_by_path with three mandatory arguments
-# (PARENT_PATH, REGEX, GROUP, ...)
-# to group source files in folders (e.g. for MSVC solutions).
-#
-# Example:
-# source_group_by_path("${CMAKE_CURRENT_SOURCE_DIR}/src"
-# "\\\\.h$|\\\\.hpp$|\\\\.cpp$|\\\\.c$|\\\\.ui$|\\\\.qrc$" "Source Files" ${sources})
-function(source_group_by_path PARENT_PATH REGEX GROUP)
-    foreach (FILENAME ${ARGN})
-        get_filename_component(FILEPATH "${FILENAME}" REALPATH)
-        file(RELATIVE_PATH FILEPATH ${PARENT_PATH} ${FILEPATH})
-        get_filename_component(FILEPATH "${FILEPATH}" DIRECTORY)
-        string(REPLACE "/" "\\" FILEPATH "${FILEPATH}")
-	      source_group("${GROUP}\\${FILEPATH}" REGULAR_EXPRESSION "${REGEX}" FILES ${FILENAME})
-    endforeach()
-endfunction(source_group_by_path)
-
 function(source_group_by_path_all PARENT_PATH)
     foreach (FILENAME ${ARGN})
         get_filename_component(FILEPATH "${FILENAME}" REALPATH)
         file(RELATIVE_PATH FILEPATH ${PARENT_PATH} ${FILEPATH})
         get_filename_component(FILEPATH "${FILEPATH}" DIRECTORY)
         string(REPLACE "/" "\\" FILEPATH "${FILEPATH}")
-    source_group("${FILEPATH}" FILES ${FILENAME})
-endforeach()
-
+        source_group("${FILEPATH}" FILES ${FILENAME})
+    endforeach()
 endfunction(source_group_by_path_all)
 
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -33,7 +33,8 @@ include_directories(SYSTEM "earcut.hpp")
 set(EARCUT_HPP_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/earcut.hpp/include/mapbox
     CACHE INTERNAL "Include directories of Earcut hpp")
-
+add_library(earcut_hpp INTERFACE)
+target_include_directories(earcut_hpp INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/earcut.hpp/include/mapbox)
 
 # json.hpp (JSON for Modern C++)
 include_directories("json.hpp")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -24,15 +24,6 @@ if(OPTION_BUILD_TESTS)
         gmock_build_tests gtest_build_samples gtest_build_tests
         gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
     )
-    macro(babylon_add_test TESTNAME)
-        message("babylon_add_test ${TESTNAME}")
-        add_executable(${TESTNAME} ${ARGN})
-        # Create namespaced alias
-        add_executable(${META_PROJECT_NAME}::${TESTNAME} ALIAS ${TESTNAME})
-
-        target_link_libraries(${TESTNAME} PRIVATE gtest gmock gtest_main)
-        add_test(NAME ${TESTNAME} COMMAND ${TESTNAME})
-    endmacro()
     add_subdirectory(googletest)
 endif(OPTION_BUILD_TESTS)
 

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -14,9 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Namespace
-set(BABYLON_NAMESPACE babylon)
-
 # Set API export file and macro
 string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -19,22 +19,9 @@ message(STATUS "Lib ${TARGET}")
 #                       Project description and (meta) information             #
 # ============================================================================ #
 
-# Get git revision
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
-
 # Meta information about the project
 set(META_PROJECT_NAME        "BabylonCpp")
 set(META_PROJECT_DESCRIPTION "BabylonCpp - A port of Babylon.js to C++")
-set(META_AUTHOR_ORGANIZATION "")
-set(META_AUTHOR_DOMAIN       "")
-set(META_AUTHOR_MAINTAINER   "")
-set(META_VERSION_MAJOR       "4")
-set(META_VERSION_MINOR       "0")
-set(META_VERSION_PATCH       "0")
-set(META_VERSION_REVISION    "${GIT_REV}")
-set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
-set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
 
 # Generate version-header
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -85,21 +85,13 @@ export(TARGETS ${TARGET} NAMESPACE ${META_PROJECT_NAME}:: FILE ${CMAKE_OUTPUT_PA
 # Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
 
 # Check for availability of module; use pre-generated version if not found
-if (WriterCompilerDetectionHeaderFound)
-    write_compiler_detection_header(
-        FILE ${FEATURE_FILE}
-        PREFIX ${BABYLON_UPPER}
-        COMPILERS AppleClang Clang GNU MSVC
-        FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-        VERSION 3.2
-    )
-else()
-    file(
-        COPY ${PROJECT_SOURCE_DIR}/codegeneration/${TARGET}_features.h
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/${TARGET}
-        USE_SOURCE_PERMISSIONS
-    )
-endif()
+write_compiler_detection_header(
+    FILE ${FEATURE_FILE}
+    PREFIX ${BABYLON_UPPER}
+    COMPILERS AppleClang Clang GNU MSVC
+    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
+    VERSION 3.2
+)
 
 # Create API export header
 generate_export_header(${TARGET}

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -14,11 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
-set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
-set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 
 # ============================================================================ #
 #                       Project description and (meta) information             #

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -15,10 +15,10 @@ project(${TARGET} C CXX)
 message(STATUS "Lib ${TARGET}")
 
 # Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
+string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
 set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${TARGET_UPPER}_SHARED_EXPORT")
+set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 
 # ============================================================================ #
 #                       Project description and (meta) information             #
@@ -106,7 +106,7 @@ export(TARGETS ${TARGET} NAMESPACE ${META_PROJECT_NAME}:: FILE ${CMAKE_OUTPUT_PA
 if (WriterCompilerDetectionHeaderFound)
     write_compiler_detection_header(
         FILE ${FEATURE_FILE}
-        PREFIX ${TARGET_UPPER}
+        PREFIX ${BABYLON_UPPER}
         COMPILERS AppleClang Clang GNU MSVC
         FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
         VERSION 3.2
@@ -149,7 +149,7 @@ target_include_directories(${TARGET}
 # Compile definitions
 target_compile_definitions(${TARGET}
     PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${TARGET_UPPER}_STATIC_DEFINE>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
     BABYLON_REPO_FOLDER="${CMAKE_SOURCE_DIR}"
 )
 # Compile options

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -8,9 +8,6 @@ include(../../cmake/BuildEnvironment.cmake)
 # Target name
 set(TARGET BabylonCpp)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "Lib ${TARGET}")
 

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -52,8 +52,6 @@ file(GLOB_RECURSE BABYLON_SOURCES
     ${SOURCE_PATH}/*.c
     )
 
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_HEADERS} ${BABYLON_SOURCES})
-
 # ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -59,29 +59,17 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_HEADERS} ${BABYLO
 # ============================================================================ #
 
 # Build library
-add_library(${TARGET}
+babylon_add_library(${TARGET}
     ${BABYLON_SOURCES}
     ${BABYLON_HEADERS}
 )
-babylon_target_clang_tidy(${TARGET})
-
 
 if (OPTION_ENABLE_SIMD)
     target_compile_definitions(${TARGET} PRIVATE OPTION_ENABLE_SIMD)
 endif()
 
-
-# Create namespaced alias
-add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
-
 # Export library for downstream projects
 export(TARGETS ${TARGET} NAMESPACE ${META_PROJECT_NAME}:: FILE ${CMAKE_OUTPUT_PATH}/${TARGET}-export.cmake)
-
-# Create API export header
-generate_export_header(${TARGET}
-    EXPORT_FILE_NAME  ${EXPORT_FILE}
-    EXPORT_MACRO_NAME ${EXPORT_MACRO}
-)
 
 # Include directories
 target_include_directories(${TARGET}
@@ -104,24 +92,7 @@ target_include_directories(${TARGET}
     $<BUILD_INTERFACE:${PROMISE_CPP_INCLUDE_DIR}>
 )
 
-# Compile definitions
-target_compile_definitions(${TARGET}
-    PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
-    BABYLON_REPO_FOLDER="${CMAKE_SOURCE_DIR}"
-)
-# Compile options
-target_compile_options(${TARGET}
-    PUBLIC
-)
-
-# Set library ouput name
-set_target_properties(${TARGET}
-    PROPERTIES  PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
-                OUTPUT_NAME $<LOWER_CASE:${TARGET}>
-                VERSION ${META_VERSION}
-                SOVERSION ${META_VERSION}
-)
+target_compile_definitions(${TARGET} PUBLIC BABYLON_REPO_FOLDER="${CMAKE_SOURCE_DIR}")
 
 # ============================================================================ #
 #                        Include What You Use                                  #

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -35,32 +35,11 @@ set(OPTION_ENABLE_SIMD        false)
 configure_file(options.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_options.h)
 
 # ============================================================================ #
-#                       Sources                                                #
-# ============================================================================ #
-
-# Include, Source
-set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}")
-set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
-
-file(GLOB_RECURSE BABYLON_HEADERS
-    ${INCLUDE_PATH}/*.h
-    ${INCLUDE_PATH}/*.hpp
-    )
-file(GLOB_RECURSE BABYLON_SOURCES
-    ${SOURCE_PATH}/*.cpp
-    ${SOURCE_PATH}/*.c
-    )
-
-# ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #
 
 # Build library
-babylon_add_library(${TARGET}
-    ${BABYLON_SOURCES}
-    ${BABYLON_HEADERS}
-)
+babylon_add_library_glob(${TARGET})
 
 if (OPTION_ENABLE_SIMD)
     target_compile_definitions(${TARGET} PRIVATE OPTION_ENABLE_SIMD)
@@ -71,23 +50,16 @@ export(TARGETS ${TARGET} NAMESPACE ${META_PROJECT_NAME}:: FILE ${CMAKE_OUTPUT_PA
 
 # Include directories
 target_include_directories(${TARGET}
-    PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    PUBLIC
-    INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-
-# Libraries
-target_include_directories(${TARGET}
     PRIVATE SYSTEM
-    ${EARCUT_HPP_INCLUDE_DIRS}
-    ${JSON_HPP_INCLUDE_DIRS}
+        ${EARCUT_HPP_INCLUDE_DIRS}
+        ${JSON_HPP_INCLUDE_DIRS}
     PUBLIC
-    $<BUILD_INTERFACE:${STB_IMAGE_INCLUDE_DIR}>
-    $<BUILD_INTERFACE:${PROMISE_CPP_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${STB_IMAGE_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${PROMISE_CPP_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    INTERFACE
+        $<INSTALL_INTERFACE:include>
 )
 
 target_compile_definitions(${TARGET} PUBLIC BABYLON_REPO_FOLDER="${CMAKE_SOURCE_DIR}")

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -80,19 +80,6 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 # Export library for downstream projects
 export(TARGETS ${TARGET} NAMESPACE ${META_PROJECT_NAME}:: FILE ${CMAKE_OUTPUT_PATH}/${TARGET}-export.cmake)
 
-# Create feature detection header
-# Compilers: https://cmake.org/cmake/help/v3.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
-# Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-
-# Check for availability of module; use pre-generated version if not found
-write_compiler_detection_header(
-    FILE ${FEATURE_FILE}
-    PREFIX ${BABYLON_UPPER}
-    COMPILERS AppleClang Clang GNU MSVC
-    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-    VERSION 3.2
-)
-
 # Create API export header
 generate_export_header(${TARGET}
     EXPORT_FILE_NAME  ${EXPORT_FILE}

--- a/src/BabylonCpp/benchmarks/CMakeLists.txt
+++ b/src/BabylonCpp/benchmarks/CMakeLists.txt
@@ -6,7 +6,6 @@ if (BABYLON_BUILD_BENCHMARK)
 
     file(GLOB_RECURSE SRC_FILES *.cpp)
     babylon_add_test(${TARGET} ${SRC_FILES})
-    babylon_target_clang_tidy(${TARGET})
 
     # Libraries
     target_link_libraries(${TARGET} PRIVATE BabylonCpp)

--- a/src/BabylonCpp/include/babylon/engines/extensions/transform_feedback_extension.h
+++ b/src/BabylonCpp/include/babylon/engines/extensions/transform_feedback_extension.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include <babylon/babylon_api.h>
 

--- a/src/BabylonCpp/tests/CMakeLists.txt
+++ b/src/BabylonCpp/tests/CMakeLists.txt
@@ -3,5 +3,4 @@ message(STATUS "Tests ${TARGET}")
 
 file(GLOB_RECURSE sources *.h *.cpp)
 babylon_add_test(${TARGET} ${sources})
-babylon_target_clang_tidy(${TARGET})
 target_link_libraries(${TARGET} PRIVATE BabylonCpp json_hpp)

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -96,12 +96,6 @@ if (BABYLON_BUILD_PLAYGROUND)
     target_compile_definitions(${TARGET} PRIVATE -DBABYLON_BUILD_PLAYGROUND)
 endif()
 
-# Compile options
-target_compile_options(${TARGET}
-    PRIVATE
-    PUBLIC
-)
-
 # Set library ouput name
 set_target_properties(${TARGET}
     PROPERTIES  PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -14,9 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Namespace
-set(BABYLON_NAMESPACE babylon)
-
 # Set API export file and macro
 string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -18,22 +18,9 @@ message(STATUS "Lib ${TARGET}")
 #                       Project description and (meta) information             #
 # ============================================================================ #
 
-# Get git revision
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
-
 # Meta information about the project
 set(META_PROJECT_NAME        "imgui_babylon")
 set(META_PROJECT_DESCRIPTION "Inspector and imgui scene widget for BabylonCpp")
-set(META_AUTHOR_ORGANIZATION "")
-set(META_AUTHOR_DOMAIN       "")
-set(META_AUTHOR_MAINTAINER   "")
-set(META_VERSION_MAJOR       "4")
-set(META_VERSION_MINOR       "0")
-set(META_VERSION_PATCH       "0")
-set(META_VERSION_REVISION    "${GIT_REV}")
-set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
-set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
 
 # Generate version-header
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -35,8 +35,6 @@ set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
 file(GLOB_RECURSE BABYLON_INSPECTOR_HEADERS ${INCLUDE_PATH}/*.h)
 file(GLOB_RECURSE BABYLON_INSPECTOR_SOURCES ${SOURCE_PATH}/*.cpp)
 
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_INSPECTOR_HEADERS} ${BABYLON_INSPECTOR_SOURCES})
-
 # ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -56,19 +56,6 @@ babylon_target_clang_tidy(${TARGET})
 # Create namespaced alias
 add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 
-# Create feature detection header
-# Compilers: https://cmake.org/cmake/help/v3.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
-# Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-
-# Check for availability of module; use pre-generated version if not found
-write_compiler_detection_header(
-    FILE ${FEATURE_FILE}
-    PREFIX ${BABYLON_UPPER}
-    COMPILERS AppleClang Clang GNU MSVC
-    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-    VERSION 3.2
-)
-
 # Create API export header
 generate_export_header(${TARGET}
     EXPORT_FILE_NAME  ${EXPORT_FILE}

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -14,12 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
-set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
-set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
-
 # ============================================================================ #
 #                       Project description and (meta) information             #
 # ============================================================================ #

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -61,21 +61,13 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 # Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
 
 # Check for availability of module; use pre-generated version if not found
-if (WriterCompilerDetectionHeaderFound)
-    write_compiler_detection_header(
-        FILE ${FEATURE_FILE}
-        PREFIX ${BABYLON_UPPER}
-        COMPILERS AppleClang Clang GNU MSVC
-        FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-        VERSION 3.2
-    )
-else()
-    file(
-        COPY ${PROJECT_SOURCE_DIR}/codegeneration/${TARGET}_features.h
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/${TARGET}
-        USE_SOURCE_PERMISSIONS
-    )
-endif()
+write_compiler_detection_header(
+    FILE ${FEATURE_FILE}
+    PREFIX ${BABYLON_UPPER}
+    COMPILERS AppleClang Clang GNU MSVC
+    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
+    VERSION 3.2
+)
 
 # Create API export header
 generate_export_header(${TARGET}

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -24,28 +24,11 @@ string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_version.h)
 
 # ============================================================================ #
-#                       Sources                                                #
-# ============================================================================ #
-
-# Include, Source
-set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}")
-set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
-# Header files
-file(GLOB_RECURSE BABYLON_INSPECTOR_HEADERS ${INCLUDE_PATH}/*.h)
-file(GLOB_RECURSE BABYLON_INSPECTOR_SOURCES ${SOURCE_PATH}/*.cpp)
-
-# ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #
 
 # Build library
-babylon_add_library(${TARGET}
-    STATIC
-    ${BABYLON_INSPECTOR_SOURCES}
-    ${BABYLON_INSPECTOR_HEADERS}
-    Readme.md
-)
+babylon_add_library_glob(${TARGET})
 
 # Include directories
 target_include_directories(${TARGET}

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -8,9 +8,6 @@ include(../../cmake/BuildEnvironment.cmake)
 # Target name
 set(TARGET BabylonImGui)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "Lib ${TARGET}")
 

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -42,21 +42,11 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_INSPECTOR_HEADERS
 # ============================================================================ #
 
 # Build library
-add_library(${TARGET}
+babylon_add_library(${TARGET}
     STATIC
     ${BABYLON_INSPECTOR_SOURCES}
     ${BABYLON_INSPECTOR_HEADERS}
     Readme.md
-)
-babylon_target_clang_tidy(${TARGET})
-
-# Create namespaced alias
-add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
-
-# Create API export header
-generate_export_header(${TARGET}
-    EXPORT_FILE_NAME  ${EXPORT_FILE}
-    EXPORT_MACRO_NAME ${EXPORT_MACRO}
 )
 
 # Include directories
@@ -86,23 +76,9 @@ if (APPLE AND NOT EMSCRIPTEN) # Special case for Apple OpenGL framework
     target_link_libraries(${TARGET} PRIVATE "-framework OpenGL")
 endif()
 
-# Compile definitions
-target_compile_definitions(${TARGET}
-    PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
-)
-
 if (BABYLON_BUILD_PLAYGROUND)
     target_compile_definitions(${TARGET} PRIVATE -DBABYLON_BUILD_PLAYGROUND)
 endif()
-
-# Set library ouput name
-set_target_properties(${TARGET}
-    PROPERTIES  PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
-                OUTPUT_NAME $<LOWER_CASE:${TARGET}>
-                VERSION ${META_VERSION}
-                SOVERSION ${META_VERSION}
-)
 
 # ============================================================================ #
 #                       Deployment                                             #

--- a/src/BabylonImGui/CMakeLists.txt
+++ b/src/BabylonImGui/CMakeLists.txt
@@ -15,10 +15,10 @@ project(${TARGET} C CXX)
 message(STATUS "Lib ${TARGET}")
 
 # Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
+string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
 set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${TARGET_UPPER}_SHARED_EXPORT")
+set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 
 # ============================================================================ #
 #                       Project description and (meta) information             #
@@ -83,7 +83,7 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 if (WriterCompilerDetectionHeaderFound)
     write_compiler_detection_header(
         FILE ${FEATURE_FILE}
-        PREFIX ${TARGET_UPPER}
+        PREFIX ${BABYLON_UPPER}
         COMPILERS AppleClang Clang GNU MSVC
         FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
         VERSION 3.2
@@ -132,7 +132,7 @@ endif()
 # Compile definitions
 target_compile_definitions(${TARGET}
     PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${TARGET_UPPER}_STATIC_DEFINE>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
 )
 
 if (BABYLON_BUILD_PLAYGROUND)

--- a/src/BabylonImGui/include/babylon/babylon_imgui/babylon_studio.h
+++ b/src/BabylonImGui/include/babylon/babylon_imgui/babylon_studio.h
@@ -6,17 +6,18 @@
 #include <functional>
 #include <imgui_utils/imgui_runner_babylon/runner_babylon.h>
 #include <imgui_utils/code_editor.h>
+#include <babylon/babylon_api.h>
 #include <map>
 
 namespace BABYLON {
 
-  struct PlaygroundCompilerStatus
+  struct BABYLON_SHARED_EXPORT PlaygroundCompilerStatus
   {
     std::shared_ptr<IRenderableScene> _renderableScene = nullptr;
     bool _isCompiling = false;
   };
 
-  struct BabylonStudioOptions
+  struct BABYLON_SHARED_EXPORT BabylonStudioOptions
   {
     inline BabylonStudioOptions() {
       _appWindowParams.Title = "BabylonCpp";
@@ -36,7 +37,7 @@ namespace BABYLON {
     PlaygroundCompilerCallback _playgroundCompilerCallback;
   };
 
-  void runBabylonStudio(
+  void BABYLON_SHARED_EXPORT runBabylonStudio(
     const std::shared_ptr<BABYLON::IRenderableScene>& scene = nullptr,
     BabylonStudioOptions options = BabylonStudioOptions()
   );

--- a/src/BabylonImGui/include/babylon/babylon_imgui/imgui_scene_widget.h
+++ b/src/BabylonImGui/include/babylon/babylon_imgui/imgui_scene_widget.h
@@ -6,7 +6,7 @@
 #include <babylon/babylon_api.h>
 
 namespace BABYLON {
-  class ImGuiSceneWidget
+  class BABYLON_SHARED_EXPORT ImGuiSceneWidget
   {
   public:
     ImGuiSceneWidget(ImVec2 size);

--- a/src/BabylonImGui/src/GL/gl_rendering_context.cpp
+++ b/src/BabylonImGui/src/GL/gl_rendering_context.cpp
@@ -130,7 +130,7 @@ std::string GlErrorCodeStr(GLenum error_code)
 void glad_post_call_callback(const char* name, void* /*funcptr*/, int /*len_args*/, ...)
 {
   GLenum error_code;
-  error_code = glad_glGetError();
+  error_code = glGetError();
 
   std::stringstream msg_str;
   msg_str << "ERROR " << GlErrorCodeStr(error_code) << "(" << error_code << ") in " << name << "\n";

--- a/src/BabylonStudio/CMakeLists.txt
+++ b/src/BabylonStudio/CMakeLists.txt
@@ -60,8 +60,7 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${SOURCES_H_CPP})
 # ============================================================================ #
 
 # Build executable
-add_executable(${TARGET} ${SOURCES_H_CPP})
-babylon_target_clang_tidy(${TARGET})
+babylon_add_executable(${TARGET} ${SOURCES_H_CPP})
 
 # Libraries
 target_link_libraries(${TARGET}

--- a/src/BabylonStudio/CMakeLists.txt
+++ b/src/BabylonStudio/CMakeLists.txt
@@ -53,7 +53,6 @@ file(GLOB_RECURSE SOURCES_H_CPP
     ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/*.md
     )
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${SOURCES_H_CPP})
 
 # ============================================================================ #
 #                       Create executable                                      #

--- a/src/BabylonStudio/CMakeLists.txt
+++ b/src/BabylonStudio/CMakeLists.txt
@@ -39,9 +39,6 @@ include_directories(${OPENGL_INCLUDE_DIRS})
 # Target name
 set(TARGET BabylonStudio)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "App ${TARGET}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ option(OPTION_BUILD_IMGUI_BABYLON "Build the inspector debugging tool."  ON)
 # Common variables used by all sub projects                                    #
 # ============================================================================ #
 include(../cmake/BuildEnvironment.cmake)
+include(../cmake/BabylonAddTest.cmake)
 
 set(BABYLON_NAMESPACE babylon)
 string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
@@ -46,6 +47,11 @@ write_compiler_detection_header(
     FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
     VERSION 3.2
 )
+
+# ============================================================================ #
+#                            babylon_add_library                               #
+# ============================================================================ #
+
 
 
 # ============================================================================ #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ option(OPTION_BUILD_IMGUI_BABYLON "Build the inspector debugging tool."  ON)
 # ============================================================================ #
 include(../cmake/BuildEnvironment.cmake)
 include(../cmake/BabylonAddTest.cmake)
+include(../cmake/BabylonAddLibrary.cmake)
 
 set(BABYLON_NAMESPACE babylon)
 string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,20 @@ set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERS
 #set(META_PROJECT_DESCRIPTION "")
 
 
+# Create feature detection header
+# Compilers: https://cmake.org/cmake/help/v3.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
+# Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
+
+# Check for availability of module; use pre-generated version if not found
+write_compiler_detection_header(
+    FILE ${FEATURE_FILE}
+    PREFIX ${BABYLON_UPPER}
+    COMPILERS AppleClang Clang GNU MSVC
+    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
+    VERSION 3.2
+)
+
+
 # ============================================================================ #
 #                            Sub-projects                                      #
 # ============================================================================ #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,6 @@
 #                            Configuration options                             #
 # ============================================================================ #
 option(OPTION_BUILD_IMGUI_BABYLON "Build the inspector debugging tool."  ON)
-option(OPTION_BUILD_LOADERS       "Build the loader plugins."            ON)
 
 # ============================================================================ #
 #                            Sub-projects                                      #
@@ -15,9 +14,7 @@ add_subdirectory(Extensions)
 add_subdirectory(MaterialsLibrary)
 add_subdirectory(ProceduralTexturesLibrary)
 add_subdirectory(Samples)
-if (OPTION_BUILD_LOADERS)
-    add_subdirectory(Loaders)
-endif()
+add_subdirectory(Loaders)
 if (OPTION_BUILD_IMGUI_BABYLON)
     add_subdirectory(BabylonImGui)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,8 @@ option(OPTION_BUILD_IMGUI_BABYLON "Build the inspector debugging tool."  ON)
 #                            Sub-projects                                      #
 # ============================================================================ #
 
+set(BABYLON_NAMESPACE babylon)
+
 #-- Libraries --##
 add_subdirectory(imgui_utils)
 add_subdirectory(BabylonCpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,13 @@ option(OPTION_BUILD_IMGUI_BABYLON "Build the inspector debugging tool."  ON)
 #                            Sub-projects                                      #
 # ============================================================================ #
 
+# Common variables used by all sub libraries
 set(BABYLON_NAMESPACE babylon)
+string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
+set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
+set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
+set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
+
 
 #-- Libraries --##
 add_subdirectory(imgui_utils)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,16 +3,40 @@
 # ============================================================================ #
 option(OPTION_BUILD_IMGUI_BABYLON "Build the inspector debugging tool."  ON)
 
-# ============================================================================ #
-#                            Sub-projects                                      #
-# ============================================================================ #
 
-# Common variables used by all sub libraries
+# ============================================================================ #
+# Common variables used by all sub projects                                    #
+# ============================================================================ #
+include(../cmake/BuildEnvironment.cmake)
+
 set(BABYLON_NAMESPACE babylon)
 string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
 set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
 set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
+
+# Get git revision
+get_git_head_revision(GIT_REFSPEC GIT_SHA1)
+string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
+
+# Meta information about the projects
+set(META_AUTHOR_ORGANIZATION "")
+set(META_AUTHOR_DOMAIN       "")
+set(META_AUTHOR_MAINTAINER   "")
+set(META_VERSION_MAJOR       "4")
+set(META_VERSION_MINOR       "0")
+set(META_VERSION_PATCH       "0")
+set(META_VERSION_REVISION    "${GIT_REV}")
+set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
+set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
+# You need set META_PROJECT_NAME and META_PROJECT_DESCRIPTION project by project
+#set(META_PROJECT_NAME        "")
+#set(META_PROJECT_DESCRIPTION "")
+
+
+# ============================================================================ #
+#                            Sub-projects                                      #
+# ============================================================================ #
 
 
 #-- Libraries --##

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -14,9 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Namespace
-set(BABYLON_NAMESPACE babylon)
-
 # Set API export file and macro
 string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -15,10 +15,10 @@ project(${TARGET} C CXX)
 message(STATUS "Lib ${TARGET}")
 
 # Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
+string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
 set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${TARGET_UPPER}_SHARED_EXPORT")
+set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 
 # ============================================================================ #
 #                       Project description and (meta) information             #
@@ -80,7 +80,7 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 if (WriterCompilerDetectionHeaderFound)
     write_compiler_detection_header(
         FILE ${FEATURE_FILE}
-        PREFIX ${TARGET_UPPER}
+        PREFIX ${BABYLON_UPPER}
         COMPILERS AppleClang Clang GNU MSVC
         FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
         VERSION 3.2
@@ -125,7 +125,7 @@ target_link_libraries(${TARGET}
 # Compile definitions
 target_compile_definitions(${TARGET}
     PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${TARGET_UPPER}_STATIC_DEFINE>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
 )
 
 # Set library ouput name

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -8,9 +8,6 @@ include(../../cmake/BuildEnvironment.cmake)
 # Target name
 set(TARGET Extensions)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "Lib ${TARGET}")
 

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -24,26 +24,11 @@ string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_version.h)
 
 # ============================================================================ #
-#                       Sources                                                #
-# ============================================================================ #
-
-# Include, Source and Tests path
-set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}")
-set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
-# Header files
-file(GLOB_RECURSE BABYLON_EXTENSIONS_HEADERS  ${INCLUDE_PATH}/*.h)
-file(GLOB_RECURSE BABYLON_EXTENSIONS_SOURCES  ${SOURCE_PATH}/*.cpp)
-
-# ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #
 
 # Build library
-babylon_add_library(${TARGET}
-    ${BABYLON_EXTENSIONS_SOURCES}
-    ${BABYLON_EXTENSIONS_HEADERS}
-)
+babylon_add_library_glob(${TARGET})
 
 # Include directories
 target_include_directories(${TARGET}
@@ -54,10 +39,10 @@ target_include_directories(${TARGET}
     ${CMAKE_CURRENT_BINARY_DIR}/../BabylonCpp/include
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${INCLUDE_PATH}/../recastnavigation/Detour/Include>
-    $<BUILD_INTERFACE:${INCLUDE_PATH}/../recastnavigation/DetourCrowd/Include>
-    $<BUILD_INTERFACE:${INCLUDE_PATH}/../recastnavigation/DetourTileCache/Include>
-    $<BUILD_INTERFACE:${INCLUDE_PATH}/../recastnavigation/Recast/Include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/recastnavigation/Detour/Include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/recastnavigation/DetourCrowd/Include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/recastnavigation/DetourTileCache/Include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/recastnavigation/Recast/Include>
 )
 
 # Libraries

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -24,22 +24,9 @@ set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 #                       Project description and (meta) information             #
 # ============================================================================ #
 
-# Get git revision
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
-
 # Meta information about the project
 set(META_PROJECT_NAME        "Extensions")
 set(META_PROJECT_DESCRIPTION "Extensions for BabylonCpp")
-set(META_AUTHOR_ORGANIZATION "")
-set(META_AUTHOR_DOMAIN       "")
-set(META_AUTHOR_MAINTAINER   "")
-set(META_VERSION_MAJOR       "4")
-set(META_VERSION_MINOR       "0")
-set(META_VERSION_PATCH       "0")
-set(META_VERSION_REVISION    "${GIT_REV}")
-set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
-set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
 
 # Generate version-header
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -41,19 +41,9 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_EXTENSIONS_HEADER
 # ============================================================================ #
 
 # Build library
-add_library(${TARGET}
+babylon_add_library(${TARGET}
     ${BABYLON_EXTENSIONS_SOURCES}
     ${BABYLON_EXTENSIONS_HEADERS}
-)
-babylon_target_clang_tidy(${TARGET})
-
-# Create namespaced alias
-add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
-
-# Create API export header
-generate_export_header(${TARGET}
-    EXPORT_FILE_NAME  ${EXPORT_FILE}
-    EXPORT_MACRO_NAME ${EXPORT_MACRO}
 )
 
 # Include directories
@@ -77,20 +67,6 @@ target_link_libraries(${TARGET}
     PRIVATE
     BabylonCpp
     json_hpp
-)
-
-# Compile definitions
-target_compile_definitions(${TARGET}
-    PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
-)
-
-# Set library ouput name
-set_target_properties(${TARGET}
-    PROPERTIES  PREFIX "lib"
-                OUTPUT_NAME $<LOWER_CASE:${TARGET}>
-                VERSION ${META_VERSION}
-                SOVERSION ${META_VERSION}
 )
 
 # ============================================================================ #

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -14,12 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
-set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
-set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
-
 # ============================================================================ #
 #                       Project description and (meta) information             #
 # ============================================================================ #

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -105,17 +105,16 @@ generate_export_header(${TARGET}
 # Include directories
 target_include_directories(${TARGET}
     PRIVATE
-    ${INCLUDE_PATH}/../recastnavigation/Detour/Include
-    ${INCLUDE_PATH}/../recastnavigation/DetourCrowd/Include
-    ${INCLUDE_PATH}/../recastnavigation/DetourTileCache/Include
-    ${INCLUDE_PATH}/../recastnavigation/Recast/Include
     ${CMAKE_CURRENT_BINARY_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../BabylonCpp/include
     ${CMAKE_CURRENT_BINARY_DIR}/../BabylonCpp/include
     PUBLIC
-    INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${INCLUDE_PATH}/../recastnavigation/Detour/Include>
+    $<BUILD_INTERFACE:${INCLUDE_PATH}/../recastnavigation/DetourCrowd/Include>
+    $<BUILD_INTERFACE:${INCLUDE_PATH}/../recastnavigation/DetourTileCache/Include>
+    $<BUILD_INTERFACE:${INCLUDE_PATH}/../recastnavigation/Recast/Include>
 )
 
 # Libraries

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -58,21 +58,13 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 # Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
 
 # Check for availability of module; use pre-generated version if not found
-if (WriterCompilerDetectionHeaderFound)
-    write_compiler_detection_header(
-        FILE ${FEATURE_FILE}
-        PREFIX ${BABYLON_UPPER}
-        COMPILERS AppleClang Clang GNU MSVC
-        FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-        VERSION 3.2
-    )
-else()
-    file(
-        COPY ${PROJECT_SOURCE_DIR}/codegeneration/${TARGET}_features.h
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/${TARGET}
-        USE_SOURCE_PERMISSIONS
-    )
-endif()
+write_compiler_detection_header(
+    FILE ${FEATURE_FILE}
+    PREFIX ${BABYLON_UPPER}
+    COMPILERS AppleClang Clang GNU MSVC
+    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
+    VERSION 3.2
+)
 
 # Create API export header
 generate_export_header(${TARGET}

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -53,19 +53,6 @@ babylon_target_clang_tidy(${TARGET})
 # Create namespaced alias
 add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 
-# Create feature detection header
-# Compilers: https://cmake.org/cmake/help/v3.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
-# Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-
-# Check for availability of module; use pre-generated version if not found
-write_compiler_detection_header(
-    FILE ${FEATURE_FILE}
-    PREFIX ${BABYLON_UPPER}
-    COMPILERS AppleClang Clang GNU MSVC
-    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-    VERSION 3.2
-)
-
 # Create API export header
 generate_export_header(${TARGET}
     EXPORT_FILE_NAME  ${EXPORT_FILE}

--- a/src/Extensions/CMakeLists.txt
+++ b/src/Extensions/CMakeLists.txt
@@ -34,7 +34,6 @@ set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
 # Header files
 file(GLOB_RECURSE BABYLON_EXTENSIONS_HEADERS  ${INCLUDE_PATH}/*.h)
 file(GLOB_RECURSE BABYLON_EXTENSIONS_SOURCES  ${SOURCE_PATH}/*.cpp)
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_EXTENSIONS_HEADERS} ${BABYLON_EXTENSIONS_SOURCES})
 
 # ============================================================================ #
 #                       Create library                                         #

--- a/src/Extensions/tests/CMakeLists.txt
+++ b/src/Extensions/tests/CMakeLists.txt
@@ -12,7 +12,6 @@ else()
   )
 
   babylon_add_test(${TARGET} ${sources})
-  babylon_target_clang_tidy(${TARGET})
 
   target_include_directories(${TARGET}
       PRIVATE

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -39,13 +39,7 @@ file(GLOB_RECURSE BABYLON_LOADERS_HEADERS   ${INCLUDE_PATH}/*.h)
 # Source files
 file(GLOB_RECURSE BABYLON_LOADERS_SOURCES   ${SOURCE_PATH}/*.cpp)
 
-# Group source files
-set(HEADER_GROUP "Header Files (API)")
-set(SOURCE_GROUP "Source Files")
-source_group_by_path(${INCLUDE_PATH} "\\\\.h$|\\\\.hpp$"
-    ${HEADER_GROUP} ${BABYLON_LOADERS_HEADERS})
-source_group_by_path(${SOURCE_PATH}  "\\\\.cpp$|\\\\.c$|\\\\.h$|\\\\.hpp$"
-    ${SOURCE_GROUP} ${BABYLON_LOADERS_SOURCES})
+source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_LOADERS_HEADERS} ${BABYLON_LOADERS_SOURCES})
 
 # ============================================================================ #
 #                       Create library                                         #

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -14,9 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Namespace
-set(BABYLON_NAMESPACE babylon)
-
 # Set API export file and macro
 string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -24,27 +24,11 @@ string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_version.h)
 
 # ============================================================================ #
-#                       Sources                                                #
-# ============================================================================ #
-
-# Include, Source
-set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}")
-set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
-# Header files
-file(GLOB_RECURSE BABYLON_LOADERS_HEADERS   ${INCLUDE_PATH}/*.h)
-# Source files
-file(GLOB_RECURSE BABYLON_LOADERS_SOURCES   ${SOURCE_PATH}/*.cpp)
-
-# ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #
 
 # Build library
-babylon_add_library(${TARGET}
-    ${BABYLON_LOADERS_SOURCES}
-    ${BABYLON_LOADERS_HEADERS}
-)
+babylon_add_library_glob(${TARGET})
 
 # Include directories
 target_include_directories(${TARGET}

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -43,20 +43,9 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_LOADERS_HEADERS} 
 # ============================================================================ #
 
 # Build library
-add_library(${TARGET}
+babylon_add_library(${TARGET}
     ${BABYLON_LOADERS_SOURCES}
     ${BABYLON_LOADERS_HEADERS}
-)
-babylon_target_clang_tidy(${TARGET})
-
-
-# Create namespaced alias
-add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
-
-# Create API export header
-generate_export_header(${TARGET}
-    EXPORT_FILE_NAME  ${EXPORT_FILE}
-    EXPORT_MACRO_NAME ${EXPORT_MACRO}
 )
 
 # Include directories
@@ -73,26 +62,6 @@ target_include_directories(${TARGET}
 
 # Libraries
 target_link_libraries(${TARGET} PRIVATE BabylonCpp json_hpp)
-
-# Compile definitions
-target_compile_definitions(${TARGET}
-    PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
-)
-
-# Compile options
-target_compile_options(${TARGET}
-    PRIVATE
-    PUBLIC
-)
-
-# Set library ouput name
-set_target_properties(${TARGET}
-    PROPERTIES  PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
-                OUTPUT_NAME $<LOWER_CASE:${TARGET}>
-                VERSION ${META_VERSION}
-                SOVERSION ${META_VERSION}
-)
 
 # ============================================================================ #
 #                       Setup test environment                                 #

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -8,9 +8,6 @@ include(../../cmake/BuildEnvironment.cmake)
 # Target name
 set(TARGET Loaders)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "Lib ${TARGET}")
 

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -36,8 +36,6 @@ file(GLOB_RECURSE BABYLON_LOADERS_HEADERS   ${INCLUDE_PATH}/*.h)
 # Source files
 file(GLOB_RECURSE BABYLON_LOADERS_SOURCES   ${SOURCE_PATH}/*.cpp)
 
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_LOADERS_HEADERS} ${BABYLON_LOADERS_SOURCES})
-
 # ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -56,19 +56,6 @@ babylon_target_clang_tidy(${TARGET})
 # Create namespaced alias
 add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 
-# Create feature detection header
-# Compilers: https://cmake.org/cmake/help/v3.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
-# Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-
-# Check for availability of module; use pre-generated version if not found
-write_compiler_detection_header(
-    FILE ${FEATURE_FILE}
-    PREFIX ${BABYLON_UPPER}
-    COMPILERS AppleClang Clang GNU MSVC
-    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-    VERSION 3.2
-)
-
 # Create API export header
 generate_export_header(${TARGET}
     EXPORT_FILE_NAME  ${EXPORT_FILE}

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -15,10 +15,10 @@ project(${TARGET} C CXX)
 message(STATUS "Lib ${TARGET}")
 
 # Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
+string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
 set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${TARGET_UPPER}_SHARED_EXPORT")
+set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 
 # ============================================================================ #
 #                       Project description and (meta) information             #
@@ -89,7 +89,7 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 if (WriterCompilerDetectionHeaderFound)
     write_compiler_detection_header(
         FILE ${FEATURE_FILE}
-        PREFIX ${TARGET_UPPER}
+        PREFIX ${BABYLON_UPPER}
         COMPILERS AppleClang Clang GNU MSVC
         FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
         VERSION 3.2
@@ -126,7 +126,7 @@ target_link_libraries(${TARGET} PRIVATE BabylonCpp json_hpp)
 # Compile definitions
 target_compile_definitions(${TARGET}
     PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${TARGET_UPPER}_STATIC_DEFINE>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
 )
 
 # Compile options

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -14,12 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
-set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
-set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
-
 # ============================================================================ #
 #                       Project description and (meta) information             #
 # ============================================================================ #

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -61,21 +61,13 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 # Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
 
 # Check for availability of module; use pre-generated version if not found
-if (WriterCompilerDetectionHeaderFound)
-    write_compiler_detection_header(
-        FILE ${FEATURE_FILE}
-        PREFIX ${BABYLON_UPPER}
-        COMPILERS AppleClang Clang GNU MSVC
-        FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-        VERSION 3.2
-    )
-else()
-    file(
-        COPY ${PROJECT_SOURCE_DIR}/codegeneration/${TARGET}_features.h
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/${TARGET}
-        USE_SOURCE_PERMISSIONS
-    )
-endif()
+write_compiler_detection_header(
+    FILE ${FEATURE_FILE}
+    PREFIX ${BABYLON_UPPER}
+    COMPILERS AppleClang Clang GNU MSVC
+    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
+    VERSION 3.2
+)
 
 # Create API export header
 generate_export_header(${TARGET}

--- a/src/Loaders/CMakeLists.txt
+++ b/src/Loaders/CMakeLists.txt
@@ -18,22 +18,9 @@ message(STATUS "Lib ${TARGET}")
 #                       Project description and (meta) information             #
 # ============================================================================ #
 
-# Get git revision
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
-
 # Meta information about the project
 set(META_PROJECT_NAME        "Loaders")
 set(META_PROJECT_DESCRIPTION "")
-set(META_AUTHOR_ORGANIZATION "")
-set(META_AUTHOR_DOMAIN       "")
-set(META_AUTHOR_MAINTAINER   "")
-set(META_VERSION_MAJOR       "4")
-set(META_VERSION_MINOR       "0")
-set(META_VERSION_PATCH       "0")
-set(META_VERSION_REVISION    "${GIT_REV}")
-set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
-set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
 
 # Generate version-header
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -24,27 +24,11 @@ string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_version.h)
 
 # ============================================================================ #
-#                       Sources                                                #
-# ============================================================================ #
-
-# Include, Source
-set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}")
-set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
-# Header files
-file(GLOB_RECURSE BABYLON_MATERIALS_HEADERS   ${INCLUDE_PATH}/*.h)
-# Source files
-file(GLOB_RECURSE BABYLON_MATERIALS_SOURCES ${SOURCE_PATH}/*.cpp)
-
-# ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #
 
 # Build library
-babylon_add_library(${TARGET}
-    ${BABYLON_MATERIALS_SOURCES}
-    ${BABYLON_MATERIALS_HEADERS}
-)
+babylon_add_library_glob(${TARGET})
 
 # Include directories
 target_include_directories(${TARGET}

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -14,9 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Namespace
-set(BABYLON_NAMESPACE babylon)
-
 # Set API export file and macro
 string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -18,22 +18,9 @@ message(STATUS "Lib ${TARGET}")
 #                       Project description and (meta) information             #
 # ============================================================================ #
 
-# Get git revision
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
-
 # Meta information about the project
 set(META_PROJECT_NAME        "MaterialsLibrary")
 set(META_PROJECT_DESCRIPTION "")
-set(META_AUTHOR_ORGANIZATION "")
-set(META_AUTHOR_DOMAIN       "")
-set(META_AUTHOR_MAINTAINER   "")
-set(META_VERSION_MAJOR       "4")
-set(META_VERSION_MINOR       "0")
-set(META_VERSION_PATCH       "0")
-set(META_VERSION_REVISION    "${GIT_REV}")
-set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
-set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
 
 # Generate version-header
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -8,9 +8,6 @@ include(../../cmake/BuildEnvironment.cmake)
 # Target name
 set(TARGET MaterialsLibrary)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "Lib ${TARGET}")
 

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -60,21 +60,13 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 # Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
 
 # Check for availability of module; use pre-generated version if not found
-if (WriterCompilerDetectionHeaderFound)
-    write_compiler_detection_header(
-        FILE ${FEATURE_FILE}
-        PREFIX ${BABYLON_UPPER}
-        COMPILERS AppleClang Clang GNU MSVC
-        FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-        VERSION 3.2
-    )
-else()
-    file(
-        COPY ${PROJECT_SOURCE_DIR}/codegeneration/${TARGET}_features.h
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/${TARGET}
-        USE_SOURCE_PERMISSIONS
-    )
-endif()
+write_compiler_detection_header(
+    FILE ${FEATURE_FILE}
+    PREFIX ${BABYLON_UPPER}
+    COMPILERS AppleClang Clang GNU MSVC
+    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
+    VERSION 3.2
+)
 
 # Create API export header
 generate_export_header(${TARGET}

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -15,10 +15,10 @@ project(${TARGET} C CXX)
 message(STATUS "Lib ${TARGET}")
 
 # Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
+string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
 set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${TARGET_UPPER}_SHARED_EXPORT")
+set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 
 # ============================================================================ #
 #                       Project description and (meta) information             #
@@ -82,7 +82,7 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 if (WriterCompilerDetectionHeaderFound)
     write_compiler_detection_header(
         FILE ${FEATURE_FILE}
-        PREFIX ${TARGET_UPPER}
+        PREFIX ${BABYLON_UPPER}
         COMPILERS AppleClang Clang GNU MSVC
         FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
         VERSION 3.2
@@ -120,7 +120,7 @@ target_link_libraries(${TARGET} PRIVATE BabylonCpp)
 # Compile definitions
 target_compile_definitions(${TARGET}
     PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${TARGET_UPPER}_STATIC_DEFINE>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
 )
 
 # Compile options

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -55,19 +55,6 @@ babylon_target_clang_tidy(${TARGET})
 # Create namespaced alias
 add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 
-# Create feature detection header
-# Compilers: https://cmake.org/cmake/help/v3.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
-# Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-
-# Check for availability of module; use pre-generated version if not found
-write_compiler_detection_header(
-    FILE ${FEATURE_FILE}
-    PREFIX ${BABYLON_UPPER}
-    COMPILERS AppleClang Clang GNU MSVC
-    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-    VERSION 3.2
-)
-
 # Create API export header
 generate_export_header(${TARGET}
     EXPORT_FILE_NAME  ${EXPORT_FILE}

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -14,12 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
-set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
-set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
-
 # ============================================================================ #
 #                       Project description and (meta) information             #
 # ============================================================================ #

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -43,19 +43,9 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_MATERIALS_HEADERS
 # ============================================================================ #
 
 # Build library
-add_library(${TARGET}
+babylon_add_library(${TARGET}
     ${BABYLON_MATERIALS_SOURCES}
     ${BABYLON_MATERIALS_HEADERS}
-)
-babylon_target_clang_tidy(${TARGET})
-
-# Create namespaced alias
-add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
-
-# Create API export header
-generate_export_header(${TARGET}
-    EXPORT_FILE_NAME  ${EXPORT_FILE}
-    EXPORT_MACRO_NAME ${EXPORT_MACRO}
 )
 
 # Include directories
@@ -73,26 +63,6 @@ target_include_directories(${TARGET}
 
 # Libraries
 target_link_libraries(${TARGET} PRIVATE BabylonCpp)
-
-# Compile definitions
-target_compile_definitions(${TARGET}
-    PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
-)
-
-# Compile options
-target_compile_options(${TARGET}
-    PRIVATE
-    PUBLIC
-)
-
-# Set library ouput name
-set_target_properties(${TARGET}
-    PROPERTIES  PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
-                OUTPUT_NAME $<LOWER_CASE:${TARGET}>
-                VERSION ${META_VERSION}
-                SOVERSION ${META_VERSION}
-)
 
 # ============================================================================ #
 #                       Setup test environment                                 #

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -36,8 +36,6 @@ file(GLOB_RECURSE BABYLON_MATERIALS_HEADERS   ${INCLUDE_PATH}/*.h)
 # Source files
 file(GLOB_RECURSE BABYLON_MATERIALS_SOURCES ${SOURCE_PATH}/*.cpp)
 
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_MATERIALS_HEADERS} ${BABYLON_MATERIALS_SOURCES})
-
 # ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -14,9 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Namespace
-set(BABYLON_NAMESPACE babylon)
-
 # Set API export file and macro
 string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -25,26 +25,11 @@ string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_version.h)
 
 # ============================================================================ #
-#                       Sources                                                #
-# ============================================================================ #
-
-# Include, Source
-set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}")
-set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
-file(GLOB_RECURSE BABYLON_PROCEDURALS_HEADERS ${INCLUDE_PATH}/*.h)
-file(GLOB_RECURSE BABYLON_PROCEDURALS_SOURCES ${SOURCE_PATH}/proceduraltextureslibrary/*.cpp)
-
-
-# ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #
 
 # Build library
-babylon_add_library(${TARGET}
-    ${BABYLON_PROCEDURALS_SOURCES}
-    ${BABYLON_PROCEDURALS_HEADERS}
-)
+babylon_add_library_glob(${TARGET})
 
 # Include directories
 target_include_directories(${TARGET}

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -67,13 +67,8 @@ set(BABYLON_PROCEDURALS_SOURCES
     ${PROCEDURALS_SRC_FILES}
 )
 
-# Group source files
-set(HEADER_GROUP "Header Files (API)")
-set(SOURCE_GROUP "Source Files")
-source_group_by_path(${INCLUDE_PATH} "\\\\.h$|\\\\.hpp$"
-    ${HEADER_GROUP} ${BABYLON_PROCEDURALS_HEADERS})
-source_group_by_path(${SOURCE_PATH}  "\\\\.cpp$|\\\\.c$|\\\\.h$|\\\\.hpp$"
-    ${SOURCE_GROUP} ${BABYLON_PROCEDURALS_SOURCES})
+source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_PROCEDURALS_HEADERS} ${BABYLON_PROCEDURALS_SOURCES})
+
 
 # ============================================================================ #
 #                       Create library                                         #

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -15,10 +15,10 @@ project(${TARGET} C CXX)
 message(STATUS "Lib ${TARGET}")
 
 # Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
+string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
 set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${TARGET_UPPER}_SHARED_EXPORT")
+set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 
 # ============================================================================ #
 #                       Project description and (meta) information             #
@@ -115,7 +115,7 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 if (WriterCompilerDetectionHeaderFound)
     write_compiler_detection_header(
         FILE ${FEATURE_FILE}
-        PREFIX ${TARGET_UPPER}
+        PREFIX ${BABYLON_UPPER}
         COMPILERS AppleClang Clang GNU MSVC
         FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
         VERSION 3.2
@@ -152,7 +152,7 @@ target_link_libraries(${TARGET} PRIVATE BabylonCpp json_hpp)
 # Compile definitions
 target_compile_definitions(${TARGET}
     PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${TARGET_UPPER}_STATIC_DEFINE>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
 )
 
 # Compile options

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -35,38 +35,8 @@ configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESP
 set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}")
 set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-# Header files
-file(GLOB PROCEDURALS_HDR_FILES ${INCLUDE_PATH}/proceduraltextureslibrary/brick/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/cloud/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/fire/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/grass/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/marble/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/normalmap/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/perlinnoise/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/road/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/starfield/*.h
-                                ${INCLUDE_PATH}/proceduraltextureslibrary/wood/*.h)
-
-set(BABYLON_PROCEDURALS_HEADERS
-    ${PROCEDURALS_HDR_FILES}
-)
-
-# Source files
-file(GLOB PROCEDURALS_SRC_FILES ${SOURCE_PATH}/proceduraltextureslibrary/brick/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/cloud/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/fire/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/grass/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/marble/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/normalmap/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/perlinnoise/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/road/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/starfield/*.cpp
-                                ${SOURCE_PATH}/proceduraltextureslibrary/wood/*.cpp)
-
-set(BABYLON_PROCEDURALS_SOURCES
-    ${PROCEDURALS_SRC_FILES}
-)
-
+file(GLOB_RECURSE BABYLON_PROCEDURALS_HEADERS ${INCLUDE_PATH}/*.h)
+file(GLOB_RECURSE BABYLON_PROCEDURALS_SOURCES ${SOURCE_PATH}/proceduraltextureslibrary/*.cpp)
 source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_PROCEDURALS_HEADERS} ${BABYLON_PROCEDURALS_SOURCES})
 
 

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -18,22 +18,10 @@ message(STATUS "Lib ${TARGET}")
 #                       Project description and (meta) information             #
 # ============================================================================ #
 
-# Get git revision
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
 
 # Meta information about the project
 set(META_PROJECT_NAME        "ProceduralTexturesLibrary")
 set(META_PROJECT_DESCRIPTION "")
-set(META_AUTHOR_ORGANIZATION "")
-set(META_AUTHOR_DOMAIN       "")
-set(META_AUTHOR_MAINTAINER   "")
-set(META_VERSION_MAJOR       "4")
-set(META_VERSION_MINOR       "0")
-set(META_VERSION_PATCH       "0")
-set(META_VERSION_REVISION    "${GIT_REV}")
-set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
-set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
 
 # Generate version-header
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -54,19 +54,6 @@ babylon_target_clang_tidy(${TARGET})
 # Create namespaced alias
 add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 
-# Create feature detection header
-# Compilers: https://cmake.org/cmake/help/v3.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
-# Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-
-# Check for availability of module; use pre-generated version if not found
-write_compiler_detection_header(
-    FILE ${FEATURE_FILE}
-    PREFIX ${BABYLON_UPPER}
-    COMPILERS AppleClang Clang GNU MSVC
-    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-    VERSION 3.2
-)
-
 # Create API export header
 generate_export_header(${TARGET}
     EXPORT_FILE_NAME  ${EXPORT_FILE}

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -14,12 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
-set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
-set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
-
 # ============================================================================ #
 #                       Project description and (meta) information             #
 # ============================================================================ #

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -42,19 +42,9 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_PROCEDURALS_HEADE
 # ============================================================================ #
 
 # Build library
-add_library(${TARGET}
+babylon_add_library(${TARGET}
     ${BABYLON_PROCEDURALS_SOURCES}
     ${BABYLON_PROCEDURALS_HEADERS}
-)
-babylon_target_clang_tidy(${TARGET})
-
-# Create namespaced alias
-add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
-
-# Create API export header
-generate_export_header(${TARGET}
-    EXPORT_FILE_NAME  ${EXPORT_FILE}
-    EXPORT_MACRO_NAME ${EXPORT_MACRO}
 )
 
 # Include directories
@@ -71,26 +61,6 @@ target_include_directories(${TARGET}
 
 # Libraries
 target_link_libraries(${TARGET} PRIVATE BabylonCpp json_hpp)
-
-# Compile definitions
-target_compile_definitions(${TARGET}
-    PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
-)
-
-# Compile options
-target_compile_options(${TARGET}
-    PRIVATE
-    PUBLIC
-)
-
-# Set library ouput name
-set_target_properties(${TARGET}
-    PROPERTIES  PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
-                OUTPUT_NAME $<LOWER_CASE:${TARGET}>
-                VERSION ${META_VERSION}
-                SOVERSION ${META_VERSION}
-)
 
 # ============================================================================ #
 #                       Deployment                                             #

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -59,21 +59,13 @@ add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 # Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
 
 # Check for availability of module; use pre-generated version if not found
-if (WriterCompilerDetectionHeaderFound)
-    write_compiler_detection_header(
-        FILE ${FEATURE_FILE}
-        PREFIX ${BABYLON_UPPER}
-        COMPILERS AppleClang Clang GNU MSVC
-        FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-        VERSION 3.2
-    )
-else()
-    file(
-        COPY ${PROJECT_SOURCE_DIR}/codegeneration/${TARGET}_features.h
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/${TARGET}
-        USE_SOURCE_PERMISSIONS
-    )
-endif()
+write_compiler_detection_header(
+    FILE ${FEATURE_FILE}
+    PREFIX ${BABYLON_UPPER}
+    COMPILERS AppleClang Clang GNU MSVC
+    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
+    VERSION 3.2
+)
 
 # Create API export header
 generate_export_header(${TARGET}

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -34,7 +34,6 @@ set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 file(GLOB_RECURSE BABYLON_PROCEDURALS_HEADERS ${INCLUDE_PATH}/*.h)
 file(GLOB_RECURSE BABYLON_PROCEDURALS_SOURCES ${SOURCE_PATH}/proceduraltextureslibrary/*.cpp)
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_PROCEDURALS_HEADERS} ${BABYLON_PROCEDURALS_SOURCES})
 
 
 # ============================================================================ #

--- a/src/ProceduralTexturesLibrary/CMakeLists.txt
+++ b/src/ProceduralTexturesLibrary/CMakeLists.txt
@@ -8,9 +8,6 @@ include(../../cmake/BuildEnvironment.cmake)
 # Target name
 set(TARGET ProceduralTexturesLibrary)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "Lib ${TARGET}")
 

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -14,9 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Namespace
-set(BABYLON_NAMESPACE babylon)
-
 # Set API export file and macro
 string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -48,19 +48,9 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_SAMPLES_HEADERS} 
 # ============================================================================ #
 
 # Build library
-add_library(${TARGET}
+babylon_add_library(${TARGET}
     ${BABYLON_SAMPLES_SOURCES}
     ${BABYLON_SAMPLES_HEADERS}
-)
-
-# Create namespaced alias
-add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
-babylon_target_clang_tidy(${TARGET})
-
-# Create API export header
-generate_export_header(${TARGET}
-    EXPORT_FILE_NAME  ${EXPORT_FILE}
-    EXPORT_MACRO_NAME ${EXPORT_MACRO}
 )
 
 target_include_directories(${TARGET} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
@@ -75,26 +65,6 @@ target_link_libraries(${TARGET}
     ProceduralTexturesLibrary
     Loaders
     json_hpp
-)
-
-# Compile definitions
-target_compile_definitions(${TARGET}
-    PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
-)
-
-# Compile options
-target_compile_options(${TARGET}
-    PRIVATE
-    PUBLIC
-)
-
-# Set library ouput name
-set_target_properties(${TARGET}
-    PROPERTIES  PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}"
-                OUTPUT_NAME $<LOWER_CASE:${TARGET}>
-                VERSION ${META_VERSION}
-                SOVERSION ${META_VERSION}
 )
 
 if (WIN32)

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -65,21 +65,13 @@ babylon_target_clang_tidy(${TARGET})
 # Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
 
 # Check for availability of module; use pre-generated version if not found
-if (WriterCompilerDetectionHeaderFound)
-    write_compiler_detection_header(
-        FILE ${FEATURE_FILE}
-        PREFIX ${BABYLON_UPPER}
-        COMPILERS AppleClang Clang GNU MSVC
-        FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-        VERSION 3.2
-    )
-else()
-    file(
-        COPY ${PROJECT_SOURCE_DIR}/codegeneration/${TARGET}_features.h
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include/${TARGET}
-        USE_SOURCE_PERMISSIONS
-    )
-endif()
+write_compiler_detection_header(
+    FILE ${FEATURE_FILE}
+    PREFIX ${BABYLON_UPPER}
+    COMPILERS AppleClang Clang GNU MSVC
+    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
+    VERSION 3.2
+)
 
 # Create API export header
 generate_export_header(${TARGET}

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -18,22 +18,9 @@ message(STATUS "Lib ${TARGET}")
 #                       Project description and (meta) information             #
 # ============================================================================ #
 
-# Get git revision
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
-string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
-
 # Meta information about the project
 set(META_PROJECT_NAME        "Samples")
 set(META_PROJECT_DESCRIPTION "")
-set(META_AUTHOR_ORGANIZATION "")
-set(META_AUTHOR_DOMAIN       "")
-set(META_AUTHOR_MAINTAINER   "")
-set(META_VERSION_MAJOR       "4")
-set(META_VERSION_MINOR       "0")
-set(META_VERSION_PATCH       "0")
-set(META_VERSION_REVISION    "${GIT_REV}")
-set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
-set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERSION_REVISION})")
 
 # Generate version-header
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -40,9 +40,6 @@ file(GLOB_RECURSE BABYLON_SAMPLES_SOURCES
     ${SOURCE_PATH}/*.c
     )
 
-# Group source files
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_SAMPLES_HEADERS} ${BABYLON_SAMPLES_SOURCES})
-
 # ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -14,12 +14,6 @@ project(${TARGET} C CXX)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
-# Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
-set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
-set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
-
 # ============================================================================ #
 #                       Project description and (meta) information             #
 # ============================================================================ #

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -109,36 +109,18 @@ generate_export_header(${TARGET}
     EXPORT_MACRO_NAME ${EXPORT_MACRO}
 )
 
-# Include directories
-target_include_directories(${TARGET}
-    PRIVATE
-    ${JSON_HPP_INCLUDE_DIRS}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../BabylonCpp/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../Extensions/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../Extensions/include/recastnavigation/Detour/Include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../Extensions/include/recastnavigation/DetourCrowd/Include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../Extensions/include/recastnavigation/DetourTileCache/Include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../Extensions/include/recastnavigation/Recast/Include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../MaterialsLibrary/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../ProceduralTexturesLibrary/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../Loaders/include
-    ${CMAKE_CURRENT_BINARY_DIR}/../Loaders/include
-    PUBLIC
-    INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-)
+target_include_directories(${TARGET} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 # Libraries
 target_link_libraries(${TARGET}
     PRIVATE
-    #imgui
     imgui_utils
     BabylonCpp
     Extensions
     MaterialsLibrary
     ProceduralTexturesLibrary
     Loaders
+    json_hpp
 )
 
 # Compile definitions

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -8,9 +8,6 @@ include(../../cmake/BuildEnvironment.cmake)
 # Target name
 set(TARGET Samples)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "Lib ${TARGET}")
 

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -60,19 +60,6 @@ add_library(${TARGET}
 add_library(${META_PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 babylon_target_clang_tidy(${TARGET})
 
-# Create feature detection header
-# Compilers: https://cmake.org/cmake/help/v3.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
-# Feature: https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
-
-# Check for availability of module; use pre-generated version if not found
-write_compiler_detection_header(
-    FILE ${FEATURE_FILE}
-    PREFIX ${BABYLON_UPPER}
-    COMPILERS AppleClang Clang GNU MSVC
-    FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
-    VERSION 3.2
-)
-
 # Create API export header
 generate_export_header(${TARGET}
     EXPORT_FILE_NAME  ${EXPORT_FILE}

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -15,10 +15,10 @@ project(${TARGET} C CXX)
 message(STATUS "Lib ${TARGET}")
 
 # Set API export file and macro
-string(TOUPPER ${BABYLON_NAMESPACE} TARGET_UPPER)
+string(TOUPPER ${BABYLON_NAMESPACE} BABYLON_UPPER)
 set(FEATURE_FILE "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_features.h")
 set(EXPORT_FILE  "include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_api.h")
-set(EXPORT_MACRO "${TARGET_UPPER}_SHARED_EXPORT")
+set(EXPORT_MACRO "${BABYLON_UPPER}_SHARED_EXPORT")
 
 # ============================================================================ #
 #                       Project description and (meta) information             #
@@ -87,7 +87,7 @@ babylon_target_clang_tidy(${TARGET})
 if (WriterCompilerDetectionHeaderFound)
     write_compiler_detection_header(
         FILE ${FEATURE_FILE}
-        PREFIX ${TARGET_UPPER}
+        PREFIX ${BABYLON_UPPER}
         COMPILERS AppleClang Clang GNU MSVC
         FEATURES cxx_alignas cxx_alignof cxx_constexpr cxx_final cxx_noexcept cxx_nullptr cxx_sizeof_member cxx_thread_local
         VERSION 3.2
@@ -123,7 +123,7 @@ target_link_libraries(${TARGET}
 # Compile definitions
 target_compile_definitions(${TARGET}
     PUBLIC
-    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${TARGET_UPPER}_STATIC_DEFINE>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${BABYLON_UPPER}_STATIC_DEFINE>
 )
 
 # Compile options

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -56,131 +56,17 @@ configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESP
 set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}/samples")
 set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src/samples")
 
-# Header files
-file(GLOB ANIMATIONS_HDR_FILES                      ${INCLUDE_PATH}/animations/*.h
-                                                    ${INCLUDE_PATH}/animations/easing/*.h)
-file(GLOB CAMERAS_HDR_FILES                         ${INCLUDE_PATH}/cameras/*.h)
-file(GLOB COLLISION_AND_INTERSECTIONS_HDR_FILES     ${INCLUDE_PATH}/collisionsandintersections/*.h)
-file(GLOB COMMON_HDR_FILES                          ${INCLUDE_PATH}/*.h)
-file(GLOB EXTENSIONS_HDR_FILES                      ${INCLUDE_PATH}/extensions/*.h
-                                                    ${INCLUDE_PATH}/extensions/hexplanetgeneration/*.h
-                                                    ${INCLUDE_PATH}/extensions/navigation/*.h
-                                                    ${INCLUDE_PATH}/extensions/noisegeneration/*.h
-                                                    ${INCLUDE_PATH}/extensions/polyhedron/*.h
-                                                    ${INCLUDE_PATH}/extensions/treegenerators/*.h)
-file(GLOB INTERACTIONSANDEVENTS_HDR_FILES           ${INCLUDE_PATH}/interactionsandevents/*.h)
-file(GLOB LIGHTS_HDR_FILES                          ${INCLUDE_PATH}/lights/*.h)
-if (OPTION_BUILD_LOADERS)
-    file(GLOB LOADERS_HDR_FILES                     ${INCLUDE_PATH}/loaders/*.h
-                                                    ${INCLUDE_PATH}/loaders/babylon/*.h
-                                                    ${INCLUDE_PATH}/loaders/gltf/*.h
-                                                    ${INCLUDE_PATH}/loaders/gltf/featuretestmodels/*.h
-                                                    ${INCLUDE_PATH}/loaders/gltf/furtherpbrmodels/*.h
-                                                    ${INCLUDE_PATH}/loaders/gltf/morecomplexmodels/*.h
-                                                    ${INCLUDE_PATH}/loaders/gltf/pbrmodels/*.h
-                                                    ${INCLUDE_PATH}/loaders/gltf/simplemodels/*.h)
-else()
-    file(GLOB LOADERS_HDR_FILES                     ${INCLUDE_PATH}/loaders/*.h
-                                                    ${INCLUDE_PATH}/loaders/babylon/*.h)
-endif()
-file(GLOB MATERIALS_HDR_FILES                       ${INCLUDE_PATH}/materials/*.h
-                                                    ${INCLUDE_PATH}/materials/shadermaterial/*.h)
-file(GLOB MATERIALS_LIBRARY_HDR_FILES               ${INCLUDE_PATH}/materialslibrary/*.h)
-file(GLOB MESHES_HDR_FILES                          ${INCLUDE_PATH}/meshes/*.h
-                                                    ${INCLUDE_PATH}/meshes/polygonmesh/*.h)
-file(GLOB OPTIMIZATIONS_HDR_FILES                   ${INCLUDE_PATH}/optimizations/*.h)
-file(GLOB PARTICLES_HDR_FILES                       ${INCLUDE_PATH}/particles/*.h)
-file(GLOB PROCEDURAL_TEXTURES_LIBRARY_HDR_FILES     ${INCLUDE_PATH}/proceduraltextureslibrary/*.h)
-file(GLOB SHADOWS_HDR_FILES                         ${INCLUDE_PATH}/shadows/*.h)
-file(GLOB SPECIAL_FX_HDR_FILES                      ${INCLUDE_PATH}/specialfx/*.h)
-file(GLOB TEXTURES_FX_HDR_FILES                     ${INCLUDE_PATH}/textures/*.h)
-
-set(BABYLON_SAMPLES_HEADERS
-    ${ANIMATIONS_HDR_FILES}
-    ${CAMERAS_HDR_FILES}
-    ${COLLISION_AND_INTERSECTIONS_HDR_FILES}
-    ${COMMON_HDR_FILES}
-    ${EXTENSIONS_HDR_FILES}
-    ${LIGHTS_HDR_FILES}
-    ${INTERACTIONSANDEVENTS_HDR_FILES}
-    ${LOADERS_HDR_FILES}
-    ${MATERIALS_HDR_FILES}
-    ${MATERIALS_LIBRARY_HDR_FILES}
-    ${MESHES_HDR_FILES}
-    ${OPTIMIZATIONS_HDR_FILES}
-    ${PARTICLES_HDR_FILES}
-    ${PROCEDURAL_TEXTURES_LIBRARY_HDR_FILES}
-    ${SHADOWS_HDR_FILES}
-    ${SPECIAL_FX_HDR_FILES}
-    ${TEXTURES_FX_HDR_FILES}
-)
-
-# Source files
-file(GLOB ANIMATIONS_SRC_FILES                      ${SOURCE_PATH}/animations/*.cpp
-                                                    ${SOURCE_PATH}/animations/easing/*.cpp)
-file(GLOB CAMERAS_SRC_FILES                         ${SOURCE_PATH}/cameras/*.cpp)
-file(GLOB COLLISION_AND_INTERSECTIONS_SRC_FILES     ${SOURCE_PATH}/collisionsandintersections/*.cpp)
-file(GLOB COMMON_SRC_FILES                          ${SOURCE_PATH}/*.cpp)
-file(GLOB EXTENSIONS_SRC_FILES                      ${SOURCE_PATH}/extensions/*.cpp
-                                                    ${SOURCE_PATH}/extensions/hexplanetgeneration/*.cpp
-                                                    ${SOURCE_PATH}/extensions/navigation/*.cpp
-                                                    ${SOURCE_PATH}/extensions/noisegeneration/*.cpp
-                                                    ${SOURCE_PATH}/extensions/polyhedron/*.cpp
-                                                    ${SOURCE_PATH}/extensions/treegenerators/*.cpp)
-file(GLOB INTERACTIONSANDEVENTS_SRC_FILES           ${SOURCE_PATH}/interactionsandevents/*.cpp)
-file(GLOB LIGHTS_SRC_FILES                          ${SOURCE_PATH}/lights/*.cpp)
-if (OPTION_BUILD_LOADERS)
-    file(GLOB LOADERS_SRC_FILES                     ${SOURCE_PATH}/loaders/*.cpp
-                                                    ${SOURCE_PATH}/loaders/babylon/*.cpp
-                                                    ${SOURCE_PATH}/loaders/gltf/*.cpp
-                                                    ${SOURCE_PATH}/loaders/gltf/featuretestmodels/*.cpp
-                                                    ${SOURCE_PATH}/loaders/gltf/furtherpbrmodels/*.cpp
-                                                    ${SOURCE_PATH}/loaders/gltf/morecomplexmodels/*.cpp
-                                                    ${SOURCE_PATH}/loaders/gltf/pbrmodels/*.cpp
-                                                    ${SOURCE_PATH}/loaders/gltf/simplemodels/*.cpp)
-else()
-    file(GLOB LOADERS_SRC_FILES                     ${SOURCE_PATH}/loaders/*.cpp
-                                                    ${SOURCE_PATH}/loaders/babylon/*.cpp)
-endif()
-file(GLOB MATERIALS_SRC_FILES                       ${SOURCE_PATH}/materials/*.cpp
-                                                    ${SOURCE_PATH}/materials/shadermaterial/*.cpp)
-file(GLOB MATERIALS_LIBRARY_SRC_FILES               ${SOURCE_PATH}/materialslibrary/*.cpp)
-file(GLOB MESHES_SRC_FILES                          ${SOURCE_PATH}/meshes/*.cpp
-                                                    ${SOURCE_PATH}/meshes/polygonmesh/*.cpp)
-file(GLOB OPTIMIZATIONS_SRC_FILES                   ${SOURCE_PATH}/optimizations/*.cpp)
-file(GLOB PARTICLES_SRC_FILES                       ${SOURCE_PATH}/particles/*.cpp)
-file(GLOB PROCEDURAL_TEXTURES_LIBRARY_SRC_FILES     ${SOURCE_PATH}/proceduraltextureslibrary/*.cpp)
-file(GLOB SHADOWS_SRC_FILES                         ${SOURCE_PATH}/shadows/*.cpp)
-file(GLOB SPECIAL_FX_SRC_FILES                      ${SOURCE_PATH}/specialfx/*.cpp)
-file(GLOB TEXTURES_FX_SRC_FILES                     ${SOURCE_PATH}/textures/*.cpp)
-
-set(BABYLON_SAMPLES_SOURCES
-    ${ANIMATIONS_SRC_FILES}
-    ${CAMERAS_SRC_FILES}
-    ${COLLISION_AND_INTERSECTIONS_SRC_FILES}
-    ${COMMON_SRC_FILES}
-    ${EXTENSIONS_SRC_FILES}
-    ${LIGHTS_SRC_FILES}
-    ${INTERACTIONSANDEVENTS_SRC_FILES}
-    ${LOADERS_SRC_FILES}
-    ${MATERIALS_SRC_FILES}
-    ${MATERIALS_LIBRARY_SRC_FILES}
-    ${MESHES_SRC_FILES}
-    ${OPTIMIZATIONS_SRC_FILES}
-    ${PARTICLES_SRC_FILES}
-    ${PROCEDURAL_TEXTURES_LIBRARY_SRC_FILES}
-    ${SHADOWS_SRC_FILES}
-    ${SPECIAL_FX_SRC_FILES}
-    ${TEXTURES_FX_SRC_FILES}
-)
+file(GLOB_RECURSE BABYLON_SAMPLES_HEADERS
+    ${INCLUDE_PATH}/*.h
+    ${INCLUDE_PATH}/*.hpp
+    )
+file(GLOB_RECURSE BABYLON_SAMPLES_SOURCES
+    ${SOURCE_PATH}/*.cpp
+    ${SOURCE_PATH}/*.c
+    )
 
 # Group source files
-set(HEADER_GROUP "Header Files (API)")
-set(SOURCE_GROUP "Source Files")
-source_group_by_path(${INCLUDE_PATH} "\\\\.h$|\\\\.hpp$"
-                     ${HEADER_GROUP} ${BABYLON_SAMPLES_HEADERS})
-source_group_by_path(${SOURCE_PATH}  "\\\\.cpp$|\\\\.c$|\\\\.h$|\\\\.hpp$"
-                     ${SOURCE_GROUP} ${BABYLON_SAMPLES_SOURCES})
+source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${BABYLON_SAMPLES_HEADERS} ${BABYLON_SAMPLES_SOURCES})
 
 # ============================================================================ #
 #                       Create library                                         #
@@ -236,18 +122,12 @@ target_include_directories(${TARGET}
     ${CMAKE_CURRENT_SOURCE_DIR}/../Extensions/include/recastnavigation/Recast/Include
     ${CMAKE_CURRENT_SOURCE_DIR}/../MaterialsLibrary/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../ProceduralTexturesLibrary/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../Loaders/include
+    ${CMAKE_CURRENT_BINARY_DIR}/../Loaders/include
     PUBLIC
     INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-
-if (OPTION_BUILD_LOADERS)
-    target_include_directories(${TARGET}
-        PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../Loaders/include
-        ${CMAKE_CURRENT_BINARY_DIR}/../Loaders/include
-    )
-endif()
 
 # Libraries
 target_link_libraries(${TARGET}
@@ -258,14 +138,8 @@ target_link_libraries(${TARGET}
     Extensions
     MaterialsLibrary
     ProceduralTexturesLibrary
+    Loaders
 )
-
-if (OPTION_BUILD_LOADERS)
-    target_link_libraries(${TARGET}
-        PRIVATE
-        Loaders
-    )
-endif()
 
 # Compile definitions
 target_compile_definitions(${TARGET}
@@ -332,10 +206,7 @@ if (NOT BABYLON_DISABLE_INSTALL)
 endif()
 
 # Copy asset directories
-# Loaders assets
-if (OPTION_BUILD_LOADERS)
-    copy_resource_dirs("${CMAKE_SOURCE_DIR}/assets/glTF-Sample-Models")
-endif()
+copy_resource_dirs("${CMAKE_SOURCE_DIR}/assets/glTF-Sample-Models")
 copy_resource_dirs("${CMAKE_SOURCE_DIR}/assets/scenes")
 copy_resource_dirs("${CMAKE_SOURCE_DIR}/assets/textures")
 if (EXISTS "${CMAKE_SOURCE_DIR}/assets/samples_info.json")

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -23,32 +23,13 @@ set(META_PROJECT_DESCRIPTION "")
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_version.h)
 
-# ============================================================================ #
-#                       Sources                                                #
-# ============================================================================ #
-
-# Include, Source
-set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/${BABYLON_NAMESPACE}/samples")
-set(SOURCE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/src/samples")
-
-file(GLOB_RECURSE BABYLON_SAMPLES_HEADERS
-    ${INCLUDE_PATH}/*.h
-    ${INCLUDE_PATH}/*.hpp
-    )
-file(GLOB_RECURSE BABYLON_SAMPLES_SOURCES
-    ${SOURCE_PATH}/*.cpp
-    ${SOURCE_PATH}/*.c
-    )
 
 # ============================================================================ #
 #                       Create library                                         #
 # ============================================================================ #
 
 # Build library
-babylon_add_library(${TARGET}
-    ${BABYLON_SAMPLES_SOURCES}
-    ${BABYLON_SAMPLES_HEADERS}
-)
+babylon_add_library_glob(${TARGET})
 
 target_include_directories(${TARGET} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 

--- a/src/Samples/CMakeLists.txt
+++ b/src/Samples/CMakeLists.txt
@@ -48,12 +48,6 @@ set(META_NAME_VERSION        "${META_PROJECT_NAME} v${META_VERSION} (${META_VERS
 string(TOUPPER ${META_PROJECT_NAME} META_PROJECT_NAME_UPPER)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESPACE}/${BABYLON_NAMESPACE}_version.h)
 
-# Loader plugins
-if (OPTION_BUILD_LOADERS)
-    # Set define for usage in source code
-    add_definitions(-DWITH_LOADERS)
-endif()
-
 # ============================================================================ #
 #                       Sources                                                #
 # ============================================================================ #

--- a/src/imgui_utils/CMakeLists.txt
+++ b/src/imgui_utils/CMakeLists.txt
@@ -15,12 +15,8 @@ include_directories(${OPENGL_INCLUDE_DIRS})
 # Target name
 set(TARGET imgui_utils)
 
-# Project name
-project(${TARGET} C CXX)
-
 # Print status message
 message(STATUS "App ${TARGET}")
-
 
 # ============================================================================ #
 #                       Sources                                                #

--- a/src/imgui_utils/CMakeLists.txt
+++ b/src/imgui_utils/CMakeLists.txt
@@ -34,8 +34,7 @@ source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${SOURCES_H_CPP})
 # ============================================================================ #
 
 # Build executable
-add_library(${TARGET} STATIC ${SOURCES_H_CPP} $<TARGET_OBJECTS:ImGuiColorTextEdit>)
-babylon_target_clang_tidy(${TARGET})
+babylon_add_library(${TARGET} STATIC ${SOURCES_H_CPP} $<TARGET_OBJECTS:ImGuiColorTextEdit>)
 
 # Include directories
 target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/src/imgui_utils/CMakeLists.txt
+++ b/src/imgui_utils/CMakeLists.txt
@@ -27,7 +27,6 @@ file(GLOB_RECURSE SOURCES_H_CPP
     ${CMAKE_CURRENT_SOURCE_DIR}/*.h
     ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
     )
-source_group_by_path_all(${CMAKE_CURRENT_SOURCE_DIR} ${SOURCES_H_CPP})
 
 # ============================================================================ #
 #                       Create Library                                         #

--- a/src/imgui_utils/CMakeLists.txt
+++ b/src/imgui_utils/CMakeLists.txt
@@ -32,12 +32,9 @@ file(GLOB_RECURSE SOURCES_H_CPP
 #                       Create Library                                         #
 # ============================================================================ #
 
-# Build executable
 babylon_add_library(${TARGET} STATIC ${SOURCES_H_CPP} $<TARGET_OBJECTS:ImGuiColorTextEdit>)
 
-# Include directories
 target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
-# include ImGuiColorTextEdit
 target_include_directories(${TARGET} PRIVATE SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../../external)
 
 # Libraries


### PR DESCRIPTION
Hello Sam, and happy new year !!! All the best !

This branch contains only refactorings in the CMakeLists files, because the are (lots) of duplicated code which make them hard to use.

The situation is now better (but I think the install / export parts still need refactorings). 
You will see that the cmake files got much thinner, which is good.

For example, inside src/Babylon/CMakeLists.txt, the two following lines:

````
set(TARGET BabylonCpp)
babylon_add_library_glob(${TARGET})
```` 

will automaticaclly discover all the files, create a library, run clang-tidy on it if required, generate an export header, group the sources, etc. (see [BabylonAddLibrary.cmake](https://github.com/pthom/BabylonCpp/blob/cmake_refac/cmake/BabylonAddLibrary.cmake))

Note: [src/CMakeLists.txt](https://github.com/pthom/BabylonCpp/blob/cmake_refac/src/CMakeLists.txt) now contains all the common variables, which also saves a lot of duplications.

-----

On a more global note; it seems that the windows and osx build are broken; the build succeeds, but the program fails during execution. I did not investigate further. We will soon need to create a `develop`branch so that users can trust the master branch.
