### PR TITLE
Sync load option

### DIFF
--- a/src/BabylonCpp/include/babylon/asio/asio.h
+++ b/src/BabylonCpp/include/babylon/asio/asio.h
@@ -10,7 +10,8 @@
 
 namespace BABYLON {
 namespace asio {
-  
+
+
 
 /**
  * @brief LoadUrlAsync_Text will load a text resource *asynchronously*
@@ -61,7 +62,8 @@ BABYLON_SHARED_EXPORT void Service_Stop();
 /**
  * Desesperate patch for glTF loading
  */
-BABYLON_SHARED_EXPORT void set_HACK_DISABLE_ASYNC(bool v);
+BABYLON_SHARED_EXPORT void push_HACK_DISABLE_ASYNC();
+BABYLON_SHARED_EXPORT void pop_HACK_DISABLE_ASYNC();
 
 } // namespace asio
 } // namespace BABYLON

--- a/src/BabylonCpp/src/asio/asio.cpp
+++ b/src/BabylonCpp/src/asio/asio.cpp
@@ -27,6 +27,7 @@
 #include <future>
 #include <atomic>
 #include <chrono>
+#include <cassert>
 
 
 
@@ -184,10 +185,15 @@ static std::string ArrayBufferToString(const ArrayBuffer & dataUint8)
   return dataString;
 }
 
-bool HACK_DISABLE_ASYNC = false;
-void set_HACK_DISABLE_ASYNC(bool v)
+unsigned int HACK_DISABLE_ASYNC = 0;
+void push_HACK_DISABLE_ASYNC()
 {
-  HACK_DISABLE_ASYNC = v;
+  ++HACK_DISABLE_ASYNC;
+}
+void pop_HACK_DISABLE_ASYNC()
+{
+  --HACK_DISABLE_ASYNC;
+  assert(HACK_DISABLE_ASYNC >= 0);
 }
 
 
@@ -197,7 +203,7 @@ void LoadFileAsync_Text(const std::string& filename,
                        const OnProgressFunction& onProgressFunction
                        )
 {
-  if (!HACK_DISABLE_ASYNC)
+  if (HACK_DISABLE_ASYNC == 0)
   {
     auto& service   = AsyncLoadService::Instance();
     auto syncLoader = [filename, onProgressFunction]() {
@@ -235,7 +241,7 @@ void LoadFileAsync_Binary(
   const OnProgressFunction& onProgressFunction
   )
 {
-  if (!HACK_DISABLE_ASYNC) {
+  if (HACK_DISABLE_ASYNC == 0) {
     auto & service = AsyncLoadService::Instance();
     auto syncLoader = [filename, onProgressFunction]() {
 #ifdef CAN_NAME_THREAD

--- a/src/BabylonCpp/src/asio/asio.cpp
+++ b/src/BabylonCpp/src/asio/asio.cpp
@@ -192,8 +192,8 @@ void push_HACK_DISABLE_ASYNC()
 }
 void pop_HACK_DISABLE_ASYNC()
 {
+  assert(HACK_DISABLE_ASYNC > 0);
   --HACK_DISABLE_ASYNC;
-  assert(HACK_DISABLE_ASYNC >= 0);
 }
 
 

--- a/src/BabylonCpp/src/engines/extensions/cube_texture_extension.cpp
+++ b/src/BabylonCpp/src/engines/extensions/cube_texture_extension.cpp
@@ -205,10 +205,6 @@ void CubeTextureExtension::_cascadeLoadImgs(
       files[index], [&images](const Image& img) { images.emplace_back(img); }, onError, false);
   }
 
-  // ASYNC_FIXME: Force sync because the code before seems deprecated, and is difficult to make it
-  // async
-  BABYLON::asio::Service_WaitAll_Sync();
-
   if (images.size() == 6) {
     onfinish(images);
   }

--- a/src/BabylonStudio/main.cpp
+++ b/src/BabylonStudio/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
    
   bool flagQuiet = false;
   bool flagFullscreen = false;
-  bool flagForceSync = false;
+  bool flagAsync = false;
   bool flagSpawnScreenshots = false;
   bool flagScreenshotOneSampleAndExit = false;
   bool listSamples = false;
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
     arg_cli.add_option("-s,--sample", sampleName, "Which sample to run");
     arg_cli.add_flag("-l,--list", listSamples, "List samples");
     arg_cli.add_flag("-f,--fullscreen", flagFullscreen, "run in fullscreen");
-    arg_cli.add_flag("-S,--force-sync", flagForceSync, "Force synchronous loading");
+    arg_cli.add_flag("-A,--async", flagAsync, "Use asynchronous loading");
 
     arg_cli.add_flag("-a,--shot-all-samples", flagSpawnScreenshots, "run all samples and save a screenshot");
     arg_cli.add_flag("-p,--shot-one-sample", flagScreenshotOneSampleAndExit, "run one sample, save a screenshot and exit");
@@ -45,13 +45,13 @@ int main(int argc, char** argv)
   if (!flagQuiet)
     BABYLON::initConsoleLogger();
 
-  if (flagForceSync) {
+  if (!flagAsync) {
     BABYLON::asio::push_HACK_DISABLE_ASYNC();
-    BABYLON_LOG_WARN("BabylonStudio", "Running with force-sync mode!")
+    BABYLON_LOG_WARN("BabylonStudio", "Forcing synchronous loading mode!")
   }
 
   if (flagSpawnScreenshots) {
-    BABYLON::impl::spawnScreenshots(argv[0], flagForceSync);
+    BABYLON::impl::spawnScreenshots(argv[0], flagAsync);
     exit(0);
   }
 

--- a/src/BabylonStudio/main.cpp
+++ b/src/BabylonStudio/main.cpp
@@ -2,6 +2,8 @@
 #include <babylon/babylon_imgui/babylon_studio.h>
 #include <babylon/core/logging/init_console_logger.h>
 #include <babylon/utils/CLI11.h>
+#include <babylon/asio/asio.h>
+#include <babylon/core/logging.h>
 
 #include "BabylonStudio/screenshoter/spawn_screenshots.h"
 
@@ -22,6 +24,7 @@ int main(int argc, char** argv)
    
   bool flagQuiet = false;
   bool flagFullscreen = false;
+  bool flagForceSync = false;
   bool flagSpawnScreenshots = false;
   bool flagScreenshotOneSampleAndExit = false;
   bool listSamples = false;
@@ -32,6 +35,7 @@ int main(int argc, char** argv)
     arg_cli.add_option("-s,--sample", sampleName, "Which sample to run");
     arg_cli.add_flag("-l,--list", listSamples, "List samples");
     arg_cli.add_flag("-f,--fullscreen", flagFullscreen, "run in fullscreen");
+    arg_cli.add_flag("-S,--force-sync", flagForceSync, "Force synchronous loading");
 
     arg_cli.add_flag("-a,--shot-all-samples", flagSpawnScreenshots, "run all samples and save a screenshot");
     arg_cli.add_flag("-p,--shot-one-sample", flagScreenshotOneSampleAndExit, "run one sample, save a screenshot and exit");
@@ -41,8 +45,14 @@ int main(int argc, char** argv)
   if (!flagQuiet)
     BABYLON::initConsoleLogger();
 
+  if (flagForceSync) {
+    BABYLON::asio::push_HACK_DISABLE_ASYNC();
+    BABYLON_LOG_WARN("BabylonStudio", "Running with force-sync mode!")
+  }
+
   if (flagSpawnScreenshots) {
-    BABYLON::impl::spawnScreenshots(argv[0]); exit(0);
+    BABYLON::impl::spawnScreenshots(argv[0], flagForceSync);
+    exit(0);
   }
 
   if (listSamples) {

--- a/src/BabylonStudio/screenshoter/spawn_screenshots.cpp
+++ b/src/BabylonStudio/screenshoter/spawn_screenshots.cpp
@@ -160,7 +160,7 @@ SpawnScreenshotsStats MakeEmptySpawnScreenshotsStats()
 }
 
 
-void spawnScreenshots(const std::string & exeName, bool flagForceSync)
+void spawnScreenshots(const std::string & exeName, bool flagAsync)
 {
 #ifdef _WIN32
   BABYLON_LOG_ERROR("spawnScreenshots", " needs fix under windows...");
@@ -178,8 +178,8 @@ void spawnScreenshots(const std::string & exeName, bool flagForceSync)
     BABYLON_LOG_INFO("ScreenshotAllSamples", sampleName);
 
     std::vector<std::string> command =  { exeName, "-s", sampleName, "-p"};
-    if (flagForceSync)
-      command.push_back("-S");
+    if (flagAsync)
+      command.push_back("-A");
 
     SpawnOptions spawnOptions;
     spawnOptions.MaxExecutionTimeSeconds = 15.;

--- a/src/BabylonStudio/screenshoter/spawn_screenshots.cpp
+++ b/src/BabylonStudio/screenshoter/spawn_screenshots.cpp
@@ -160,7 +160,7 @@ SpawnScreenshotsStats MakeEmptySpawnScreenshotsStats()
 }
 
 
-void spawnScreenshots(const std::string & exeName)
+void spawnScreenshots(const std::string & exeName, bool flagForceSync)
 {
 #ifdef _WIN32
   BABYLON_LOG_ERROR("spawnScreenshots", " needs fix under windows...");
@@ -178,6 +178,9 @@ void spawnScreenshots(const std::string & exeName)
     BABYLON_LOG_INFO("ScreenshotAllSamples", sampleName);
 
     std::vector<std::string> command =  { exeName, "-s", sampleName, "-p"};
+    if (flagForceSync)
+      command.push_back("-S");
+
     SpawnOptions spawnOptions;
     spawnOptions.MaxExecutionTimeSeconds = 15.;
     spawnOptions.CopyOutputToMainProgramOutput = false;

--- a/src/BabylonStudio/screenshoter/spawn_screenshots.h
+++ b/src/BabylonStudio/screenshoter/spawn_screenshots.h
@@ -4,6 +4,6 @@ namespace BABYLON {
 namespace impl {
 // this implementation will spawn a new process for each sample
 // (so that failing samples will not stop the screenshot generation)
-void spawnScreenshots(const std::string & exeName, bool flagForceSync);
+void spawnScreenshots(const std::string & exeName, bool flagAsync);
 } // namespace impl
 } // namespace BABYLON

--- a/src/BabylonStudio/screenshoter/spawn_screenshots.h
+++ b/src/BabylonStudio/screenshoter/spawn_screenshots.h
@@ -4,6 +4,6 @@ namespace BABYLON {
 namespace impl {
 // this implementation will spawn a new process for each sample
 // (so that failing samples will not stop the screenshot generation)
-void spawnScreenshots(const std::string & exeName);
+void spawnScreenshots(const std::string & exeName, bool flagForceSync);
 } // namespace impl
 } // namespace BABYLON

--- a/src/Loaders/src/loading/glTF/gltf_file_loader.cpp
+++ b/src/Loaders/src/loading/glTF/gltf_file_loader.cpp
@@ -262,16 +262,10 @@ ImportedMeshes GLTFFileLoader::importMeshAsync(
   const std::function<void(const SceneLoaderProgressEvent& event)>& onProgress,
   const std::string& fileName)
 {
-  // ASYNC_FIXME: GLTF loading is decidely incompatible with async loading
-  BABYLON::asio::push_HACK_DISABLE_ASYNC();
-
   auto loaderData = _parseAsync(scene, data, rootUrl, fileName);
   _log(StringTools::printf("Loading %s", fileName.c_str()));
   _loader = _getLoader(loaderData);
   return _loader->importMeshAsync(meshesNames, scene, loaderData, rootUrl, onProgress, fileName);
-
-  // ASYNC_FIXME: GLTF loading is decidely incompatible with async loading
-  BABYLON::asio::pop_HACK_DISABLE_ASYNC();
 }
 
 void GLTFFileLoader::loadAsync(

--- a/src/Loaders/src/loading/glTF/gltf_file_loader.cpp
+++ b/src/Loaders/src/loading/glTF/gltf_file_loader.cpp
@@ -263,7 +263,7 @@ ImportedMeshes GLTFFileLoader::importMeshAsync(
   const std::string& fileName)
 {
   // ASYNC_FIXME: GLTF loading is decidely incompatible with async loading
-  BABYLON::asio::set_HACK_DISABLE_ASYNC(true);
+  BABYLON::asio::push_HACK_DISABLE_ASYNC();
 
   auto loaderData = _parseAsync(scene, data, rootUrl, fileName);
   _log(StringTools::printf("Loading %s", fileName.c_str()));
@@ -271,7 +271,7 @@ ImportedMeshes GLTFFileLoader::importMeshAsync(
   return _loader->importMeshAsync(meshesNames, scene, loaderData, rootUrl, onProgress, fileName);
 
   // ASYNC_FIXME: GLTF loading is decidely incompatible with async loading
-  BABYLON::asio::set_HACK_DISABLE_ASYNC(false);
+  BABYLON::asio::pop_HACK_DISABLE_ASYNC();
 }
 
 void GLTFFileLoader::loadAsync(


### PR DESCRIPTION
> Debugging the file loading with all the callbacks and the asynchronous execution of code is not that easy. I will have to think more how to make it easier.

I made something that might help you!
With the command line, the argument '-A' will switch to the async mode, and if it is not present, you switch back to the sync mode.
So, I would advise to first solve the issues in sync mode first, and then we will study the async issues.

Here are the results I have now:

#### Async mode:

How to run it:

```` bash
# -a stands for "run all samples and test them / take a screenshot
# -A stands for "use async mode"
BabylonStudio -a -A 
````

And I get different results with different executions: this show we may have some races conditions:

````
{"nbEmptyRendering":11,"nbProcessFailures":120,"nbProcessHung":3,"nbSuccess":139}
{"nbEmptyRendering":10,"nbProcessFailures":133,"nbProcessHung":6,"nbSuccess":127}
````

#### Sync mode:

How to run it:

```` bash
BabylonStudio -a
````

And I get consistent results with different executions:

````
{"nbEmptyRendering":61,"nbProcessFailures":9,"nbProcessHung":3,"nbSuccess":200}
````

-----

Could you please run `BabylonStudio -a` on your side, and may be first focus on the failures in synchronous mode (9 seg fault, and 61 empty rendering)?

After you run `BabylonStudio -a`, you can find the failures by looking at file names inside the `Screenshot/`folder.

Could you also post the results you obtain on your side? I hope they are consistent but they might differ!

Thanks
