### PR TITLE
Cmake iOS and OSX build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "external/backward-cpp"]
 	path = external/backward-cpp
 	url = https://github.com/bombela/backward-cpp.git
+[submodule "external/ios-cmake"]
+	path = external/ios-cmake
+	url = https://github.com/leetal/ios-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
     set(OPTION_BUILD_TESTS_DEFAULT ON)
 endif()
 
-if (NOT BABYLON_WASM)
+if (NOT BABYLON_WASM OR NOT IOS)
     option(BUILD_SHARED_LIBS     "Build shared instead of static libraries."     ON)
 endif()
 

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -211,7 +211,12 @@ endif()
 
 # Performance
 if(NOT WIN32)
-  set(EXTRA_FLAGS "${EXTRA_FLAGS} -march=native -mpopcnt")
+  # Check for the Apple iOS platform
+  if (APPLE AND PLATFORM STREQUAL "OS64COMBINED")
+    set(EXTRA_FLAGS "${EXTRA_FLAGS} -mpopcnt")
+  else()
+    set(EXTRA_FLAGS "${EXTRA_FLAGS} -march=native -mpopcnt")
+  endif()
 endif()
 
 # Performance

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,19 +1,27 @@
 option(BUILD_OGL43 "Build OpenGL 4.3 examples" OFF)
 mark_as_advanced(BUILD_OGL43)
 
-# OpenGL dependency
-set(OpenGL_GL_PREFERENCE GLVND)
-if (NOT EMSCRIPTEN)
-    find_package(OpenGL REQUIRED)
-endif()
-include_directories(SYSTEM ${OPENGL_INCLUDE_DIRS})
-
 # Configure build environment
 include(../cmake/BuildEnvironment.cmake)
 
+if (IOS)
+  set(BUILD_SHARED_LIBS OFF)
+endif()
+
+# OpenGL dependency
+if (NOT IOS)
+    set(OpenGL_GL_PREFERENCE GLVND)
+    if (NOT EMSCRIPTEN)
+        find_package(OpenGL REQUIRED)
+    endif()
+    include_directories(SYSTEM ${OPENGL_INCLUDE_DIRS})
+endif()
+
 
 # imgui + backends (SDL, GLFW) compilation
-include("CMakeLists_imgui.cmake")
+if (NOT IOS)
+    include("CMakeLists_imgui.cmake")
+endif()
 
 
 # Build gtest and gmock + macro "babylon_add_test"
@@ -47,29 +55,31 @@ target_include_directories(json_hpp INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/json.h
 
 # glad as a standalone library
 # (in the case of emscripten, fake library that includes GlES)
-if (NOT EMSCRIPTEN)
-    set(GLAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/glad CACHE INTERNAL "Directory of glad")
-    set(GLAD_FILES
-        ${GLAD_DIR}/src/glad.c
-        ${GLAD_DIR}/include/glad/glad.h
-        ${GLAD_DIR}/include/KHR/khrplatform.h)
-    source_group_by_path_all(${GLAD_DIR} ${GLAD_FILES})
-    add_library(glad ${GLAD_FILES})
-    target_include_directories(glad PUBLIC SYSTEM ${GLAD_DIR}/include)
-    if(WIN32)
-        target_link_libraries(glad PUBLIC opengl32.lib)
+if (NOT IOS)
+    if (NOT EMSCRIPTEN)
+        set(GLAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/glad CACHE INTERNAL "Directory of glad")
+        set(GLAD_FILES
+            ${GLAD_DIR}/src/glad.c
+            ${GLAD_DIR}/include/glad/glad.h
+            ${GLAD_DIR}/include/KHR/khrplatform.h)
+        source_group_by_path_all(${GLAD_DIR} ${GLAD_FILES})
+        add_library(glad ${GLAD_FILES})
+        target_include_directories(glad PUBLIC SYSTEM ${GLAD_DIR}/include)
+        if(WIN32)
+            target_link_libraries(glad PUBLIC opengl32.lib)
+        else()
+            target_link_libraries(glad PUBLIC ${OPENGL_LIBRARIES})
+        endif()
+        get_target_property(library_type glad TYPE)
+        if (library_type STREQUAL SHARED_LIBRARY)
+            # If glad is a shared lobrary, define the macro GLAD_API_EXPORT on the command line.
+            target_compile_definitions(glad PRIVATE GLAD_GLAPI_EXPORT)
+            target_compile_definitions(glad PUBLIC GLAD_GLAPI_EXPORT PRIVATE GLAD_GLAPI_EXPORT_BUILD)
+        endif()
     else()
-        target_link_libraries(glad PUBLIC ${OPENGL_LIBRARIES})
+        add_library(glad INTERFACE)
+        target_include_directories(glad INTERFACE ${CMAKE_CURRENT_LIST_DIR}/glad_wasm_dummy/include)
     endif()
-    get_target_property(library_type glad TYPE)
-    if (library_type STREQUAL SHARED_LIBRARY)
-        # If glad is a shared lobrary, define the macro GLAD_API_EXPORT on the command line.
-        target_compile_definitions(glad PRIVATE GLAD_GLAPI_EXPORT)
-        target_compile_definitions(glad PUBLIC GLAD_GLAPI_EXPORT PRIVATE GLAD_GLAPI_EXPORT_BUILD)
-    endif()
-else()
-    add_library(glad INTERFACE)
-    target_include_directories(glad INTERFACE ${CMAKE_CURRENT_LIST_DIR}/glad_wasm_dummy/include)
 endif()
 
 

--- a/src/BabylonCpp/CMakeLists.txt
+++ b/src/BabylonCpp/CMakeLists.txt
@@ -38,6 +38,10 @@ configure_file(options.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/${BABYLON_NAMESP
 #                       Create library                                         #
 # ============================================================================ #
 
+if (IOS)
+    set(BUILD_SHARED_LIBS OFF)
+endif()
+
 # Build library
 babylon_add_library_glob(${TARGET})
 
@@ -63,6 +67,10 @@ target_include_directories(${TARGET}
 )
 
 target_compile_definitions(${TARGET} PUBLIC BABYLON_REPO_FOLDER="${CMAKE_SOURCE_DIR}")
+
+if (IOS)
+    target_compile_definitions(${TARGET} PRIVATE GLES_SILENCE_DEPRECATION GLES3=1)
+endif()
 
 # ============================================================================ #
 #                        Include What You Use                                  #

--- a/src/BabylonCpp/src/core/system.cpp
+++ b/src/BabylonCpp/src/core/system.cpp
@@ -51,7 +51,7 @@ void openBrowser(const std::string& url)
   std::string jsCode = "window.open('url','_blank');";
   jsCode             = StringTools::replace(jsCode, "url", url);
   emscripten_run_script(jsCode.c_str());
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && defined(__x86_64__)
   std::string cmd = std::string("open ") + url;
   int result      = system(cmd.c_str());
   if (result != 0)
@@ -66,14 +66,14 @@ void openBrowser(const std::string& url)
 
 void openFile(const std::string& filename)
 {
-#ifndef _WIN32
+#if defined(_WIN32)
+  std::string canonical_path = BABYLON::Filesystem::absolutePath(filename);
+  ShellExecute(0, 0, canonical_path.c_str(), 0, 0, SW_SHOW);
+#elif defined(__EMSCRIPTEN__) || defined(__APPLE__) && defined(__x86_64__) || defined(__linux__)
   std::string cmd = std::string("open ") + BABYLON::Filesystem::absolutePath(filename);
   int result      = system(cmd.c_str());
   if (result != 0)
     BABYLON_LOG_WARN("system.cpp", "system(%S) failed", cmd.c_str())
-#else
-  std::string canonical_path = BABYLON::Filesystem::absolutePath(filename);
-  ShellExecute(0, 0, canonical_path.c_str(), 0, 0, SW_SHOW);
 #endif
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,18 +60,27 @@ write_compiler_detection_header(
 
 
 #-- Libraries --##
-add_subdirectory(imgui_utils)
 add_subdirectory(BabylonCpp)
 add_subdirectory(Extensions)
 add_subdirectory(MaterialsLibrary)
 add_subdirectory(ProceduralTexturesLibrary)
-add_subdirectory(Samples)
-if (OPTION_BUILD_IMGUI_BABYLON)
-    add_subdirectory(BabylonImGui)
-endif()
 
-#-- Applications
-add_subdirectory(BabylonStudio)
-add_subdirectory(BabylonRunStandalone)
-add_subdirectory(imgui_runner_demos)
-#add_subdirectory(SampleLauncher)
+if (IOS)
+    #-- Applications
+    add_subdirectory(Standalone_iOS)
+else()
+    #-- Libraries --##
+    add_subdirectory(imgui_utils)
+    add_subdirectory(Samples)
+    if (OPTION_BUILD_IMGUI_BABYLON)
+        add_subdirectory(BabylonImGui)
+    endif()
+
+    #-- Applications
+    add_subdirectory(BabylonStudio)
+    add_subdirectory(BabylonRunStandalone)
+    add_subdirectory(imgui_runner_demos)
+    if (APPLE)
+        add_subdirectory(Standalone_OSX)
+    endif()
+endif()

--- a/src/MaterialsLibrary/CMakeLists.txt
+++ b/src/MaterialsLibrary/CMakeLists.txt
@@ -11,6 +11,10 @@ set(TARGET MaterialsLibrary)
 # Print status message
 message(STATUS "Lib ${TARGET}")
 
+if (IOS)
+  set(BUILD_SHARED_LIBS OFF)
+endif()
+
 # ============================================================================ #
 #                       Project description and (meta) information             #
 # ============================================================================ #

--- a/src/Standalone_OSX/CMakeLists.txt
+++ b/src/Standalone_OSX/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Configure build environment
+include(../../cmake/BuildEnvironment.cmake)
+
+# Target name
+set(TARGET Standalone_OSX)
+
+# Sources
+file(GLOB HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/*.*)
+file(GLOB SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.*)
+file(GLOB RESOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/resources/*.*)
+
+set(STORYBOARD_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources/Main.storyboard)
+
+babylon_add_executable(${TARGET} ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})
+
+target_include_directories(${TARGET} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_link_libraries(${TARGET} PRIVATE
+    ${OPENGL_LIBRARIES}
+    BabylonCpp
+    MaterialsLibrary
+    ProceduralTexturesLibrary
+    json_hpp
+)
+
+target_compile_definitions(${TARGET} PRIVATE GLES_SILENCE_DEPRECATION)
+
+set_target_properties(${TARGET} PROPERTIES
+    MACOSX_BUNDLE YES
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_LIST_DIR}/plist.in"
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.BabylonCpp.Standalone.OSX"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    RESOURCE "${STORYBOARD_FILES}"
+)

--- a/src/Standalone_OSX/include/BabylonManager.h
+++ b/src/Standalone_OSX/include/BabylonManager.h
@@ -1,0 +1,29 @@
+#ifndef BABYLON_MANAGER_H
+#define BABYLON_MANAGER_H
+
+#include <memory>
+
+namespace BABYLON {
+class IRenderableScene;
+}
+
+class BasicCanvas;
+
+class BabylonManager {
+public:
+  int _width = 0;
+  int _height = 0;
+  
+  BabylonManager(int width, int height);
+  ~BabylonManager();
+  
+  void render();
+  void setSize(int width, int height);
+  
+private:
+  // Babylon scene related variables
+  std::unique_ptr<BasicCanvas> _renderCanvas;
+  std::shared_ptr<BABYLON::IRenderableScene> _renderableScene;
+}; // end of class BABYLON_MANAGER_H
+
+#endif

--- a/src/Standalone_OSX/include/BabylonView.h
+++ b/src/Standalone_OSX/include/BabylonView.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+@interface BabylonView : NSObject
+
+- (instancetype)initWithSize:(CGSize)size;
+- (void)setSize:(CGSize)size;
+- (void)render;
+- (void)update;
+
+@end

--- a/src/Standalone_OSX/include/HelloScene.h
+++ b/src/Standalone_OSX/include/HelloScene.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <memory>
+#include <babylon/interfaces/icanvas.h>
+#include <babylon/interfaces/irenderable_scene.h>
+
+namespace Samples {
+
+// This files demonstrates how to create a very simple renderable scene
+std::shared_ptr<BABYLON::IRenderableScene> MakeHelloScene(BABYLON::ICanvas* canvas);
+} // end of namespace Samples

--- a/src/Standalone_OSX/include/OpenGLViewController.h
+++ b/src/Standalone_OSX/include/OpenGLViewController.h
@@ -1,0 +1,12 @@
+#import <AppKit/AppKit.h>
+#define PlatformViewBase NSOpenGLView
+#define PlatformViewController NSViewController
+#define PlatformGLContext NSOpenGLContext
+
+@interface OpenGLView : PlatformViewBase
+
+@end
+
+@interface OpenGLViewController : PlatformViewController
+
+@end

--- a/src/Standalone_OSX/include/basic_canvas.h
+++ b/src/Standalone_OSX/include/basic_canvas.h
@@ -1,0 +1,18 @@
+#ifndef BABYLON_BASIC_CANVAS_H
+#define BABYLON_BASIC_CANVAS_H
+
+#include <babylon/interfaces/icanvas.h>
+
+class BasicCanvas : public BABYLON::ICanvas {
+
+public:
+  BasicCanvas();
+  virtual ~BasicCanvas();
+
+  BABYLON::ClientRect& getBoundingClientRect() override;
+  bool initializeContext3d() override;
+  BABYLON::ICanvasRenderingContext2D* getContext2d() override;
+  BABYLON::GL::IGLRenderingContext* getContext3d(const BABYLON::EngineOptions& options) override;
+};
+
+#endif // BABYLON_BASIC_CANVAS_H

--- a/src/Standalone_OSX/include/gl_rendering_context.h
+++ b/src/Standalone_OSX/include/gl_rendering_context.h
@@ -1,0 +1,235 @@
+#ifndef BABYLON_IMPL_GL_RENDERING_CONTEXT_H
+#define BABYLON_IMPL_GL_RENDERING_CONTEXT_H
+
+#include <babylon/babylon_api.h>
+#include <babylon/interfaces/igl_rendering_context.h>
+#include <unordered_map>
+
+namespace BABYLON {
+namespace GL {
+
+class GLRenderingContext : public BABYLON::GL::IGLRenderingContext {
+
+public:
+  GLRenderingContext();
+  ~GLRenderingContext() override; // = default
+
+  bool initialize(bool enableGLDebugging = false) override;
+  GLenum operator[](const std::string& name) override;
+  void activeTexture(GLenum texture) override;
+  void attachShader(IGLProgram* program, IGLShader* shader) override;
+  void beginQuery(GLenum target, IGLQuery* query) override;
+  void beginTransformFeedback(GLenum primitiveMode) override;
+  void bindAttribLocation(IGLProgram* program, GLuint index, const std::string& name) override;
+  void bindBuffer(GLenum target, IGLBuffer* buffer) override;
+  void bindFramebuffer(GLenum target, IGLFramebuffer* framebuffer) override;
+  void bindBufferBase(GLenum target, GLuint index, IGLBuffer* buffer) override;
+  void bindRenderbuffer(GLenum target, IGLRenderbuffer* renderbuffer) override;
+  void bindTexture(GLenum target, IGLTexture* texture) override;
+  void bindTransformFeedback(GLenum target, IGLTransformFeedback* transformFeedback) override;
+  void blendColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) override;
+  void blendEquation(GLenum mode) override;
+  void blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha) override;
+  void blendFunc(GLenum sfactor, GLenum dfactor) override;
+  void blendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha) override;
+  void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
+                       GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter) override;
+  void bufferData(GLenum target, GLsizeiptr size, GLenum usage) override;
+  void bufferData(GLenum target, const Float32Array& data, GLenum usage) override;
+  void bufferData(GLenum target, const Int32Array& data, GLenum usage) override;
+  void bufferData(GLenum target, const Uint16Array& data, GLenum usage) override;
+  void bufferData(GLenum target, const Uint32Array& data, GLenum usage) override;
+  void bufferSubData(GLenum target, GLintptr offset, const Uint8Array& data) override;
+  void bufferSubData(GLenum target, GLintptr offset, const Float32Array& data) override;
+  void bufferSubData(GLenum target, GLintptr offset, Int32Array& data) override;
+  void bindVertexArray(GL::IGLVertexArrayObject* vao) override;
+  GLenum checkFramebufferStatus(GLenum target) override;
+  void clear(GLbitfield mask) override;
+  void clearBufferfv(GLenum buffer, GLint drawbuffer, const std::vector<GLfloat>& values,
+                     GLint srcOffset = 0) override;
+  void clearBufferiv(GLenum buffer, GLint drawbuffer, const std::vector<GLint>& values,
+                     GLint srcOffset = 0) override;
+  void clearBufferuiv(GLenum buffer, GLint drawbuffer, const std::vector<GLuint>& values,
+                      GLint srcOffset = 0) override;
+  void clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil) override;
+  void clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) override;
+  void clearDepth(GLclampf depth) override;
+  void clearStencil(GLint stencil) override;
+  void colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override;
+  void compileShader(IGLShader* shader) override;
+  void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
+                            GLsizei height, GLint border, const Uint8Array& pixels) override;
+  void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                               GLsizei width, GLsizei height, GLenum format,
+                               GLsizeiptr size) override;
+  void copyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y,
+                      GLsizei width, GLsizei height, GLint border) override;
+  void copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y,
+                         GLint width, GLint height) override;
+  std::shared_ptr<IGLBuffer> createBuffer() override;
+  IGLFramebufferPtr createFramebuffer() override;
+  IGLProgramPtr createProgram() override;
+  std::unique_ptr<IGLQuery> createQuery() override;
+  IGLRenderbufferPtr createRenderbuffer() override;
+  IGLShaderPtr createShader(GLenum type) override;
+  IGLTexturePtr createTexture() override;
+  IGLTransformFeedbackPtr createTransformFeedback() override;
+  IGLVertexArrayObjectPtr createVertexArray() override;
+  void cullFace(GLenum mode) override;
+  void deleteBuffer(IGLBuffer* buffer) override;
+  void deleteFramebuffer(IGLFramebuffer* framebuffer) override;
+  void deleteProgram(IGLProgram* program) override;
+  void deleteQuery(IGLQuery* query) override;
+  void deleteRenderbuffer(IGLRenderbuffer* renderbuffer) override;
+  void deleteShader(IGLShader* shader) override;
+  void deleteTexture(IGLTexture* texture) override;
+  void deleteTransformFeedback(IGLTransformFeedback* transformFeedback) override;
+  void deleteVertexArray(IGLVertexArrayObject* vao) override;
+  void depthFunc(GLenum func) override;
+  void depthMask(GLboolean flag) override;
+  void depthRange(GLclampf zNear, GLclampf zFar) override;
+  void detachShader(IGLProgram* program, IGLShader* shader) override;
+  void disable(GLenum cap) override;
+  void disableVertexAttribArray(GLuint index) override;
+  void drawArrays(GLenum mode, GLint first, GLint count) override;
+  void drawArraysInstanced(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount) override;
+  void drawBuffers(const std::vector<GLenum>& buffers) override;
+  void drawElements(GLenum mode, GLsizei count, GLenum type, GLintptr offset) override;
+  void drawElementsInstanced(GLenum mode, GLsizei count, GLenum type, GLintptr offset,
+                             GLsizei instanceCount) override;
+  void enable(GLenum cap) override;
+  void enableVertexAttribArray(GLuint index) override;
+  void endQuery(GLenum target) override;
+  void endTransformFeedback() override;
+  void finish() override;
+  void flush() override;
+  void framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget,
+                               IGLRenderbuffer* renderbuffer) override;
+  void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, IGLTexture* texture,
+                            GLint level) override;
+  void framebufferTextureLayer(GLenum target, GLenum attachment, IGLTexture* texture, GLint level,
+                               GLint layer) override;
+  void framebufferTextureMultiviewOVR(GLenum target, GLenum attachment, IGLTexture* texture,
+                                      GLint level, GLint baseViewIndex, GLint numViews) override;
+  void frontFace(GLenum mode) override;
+  void generateMipmap(GLenum target) override;
+  std::vector<IGLShader*> getAttachedShaders(IGLProgram* program) override;
+  GLint getAttribLocation(IGLProgram* program, const std::string& name) override;
+  GL::any getExtension(const std::string& name) override;
+  GLboolean hasExtension(const std::string& extension) override;
+  std::array<int, 3> getScissorBoxParameter() override; // GL::SCISSOR_BOX
+  GLint getParameteri(GLenum pname) override;
+  GLfloat getParameterf(GLenum pname) override;
+  GLboolean getQueryParameterb(IGLQuery* query, GLenum pname) override;
+  GLuint getQueryParameteri(IGLQuery* query, GLenum pname) override;
+  std::string getString(GLenum pname) override;
+  GLint getTexParameteri(GLenum pname) override;
+  GLfloat getTexParameterf(GLenum pname) override;
+  GLenum getError() override;
+  const char* getErrorString(GLenum err) override;
+  GLint getProgramParameter(IGLProgram* program, GLenum pname) override;
+  std::string getProgramInfoLog(IGLProgram* program) override;
+  GLint getRenderbufferParameter(GLenum target, GLenum pname) override;
+  std::string getShaderInfoLog(IGLShader* shader) override;
+  GLint getShaderParameter(IGLShader* shader, GLenum pname) override;
+  IGLShaderPrecisionFormat* getShaderPrecisionFormat(GLenum shadertype,
+                                                     GLenum precisiontype) override;
+  std::string getShaderSource(IGLShader* shader) override;
+  GLuint getUniformBlockIndex(IGLProgram* program, const std::string& uniformBlockName) override;
+  std::unique_ptr<IGLUniformLocation> getUniformLocation(IGLProgram* program,
+                                                         const std::string& name) override;
+  void hint(GLenum target, GLenum mode) override;
+  GLboolean isBuffer(IGLBuffer* buffer) override;
+  GLboolean isEnabled(GLenum cap) override;
+  GLboolean isFramebuffer(IGLFramebuffer* framebuffer) override;
+  GLboolean isProgram(IGLProgram* program) override;
+  GLboolean isRenderbuffer(IGLRenderbuffer* renderbuffer) override;
+  GLboolean isShader(IGLShader* shader) override;
+  GLboolean isTexture(IGLTexture* texture) override;
+  void lineWidth(GLfloat width) override;
+  bool linkProgram(IGLProgram* program) override;
+  void pixelStorei(GLenum pname, GLint param) override;
+  void polygonOffset(GLfloat factor, GLfloat units) override;
+  void readBuffer(GLenum src) override;
+  void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+                  Float32Array& pixels) override;
+  void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+                  Uint8Array& pixels) override;
+  void renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width,
+                           GLsizei height) override;
+  void renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalFormat,
+                                      GLsizei width, GLsizei height) override;
+  void sampleCoverage(GLclampf value, GLboolean invert) override;
+  void scissor(GLint x, GLint y, GLsizei width, GLsizei height) override;
+  void shaderSource(IGLShader* shader, const std::string& source) override;
+  void stencilFunc(GLenum func, GLint ref, GLuint mask) override;
+  void stencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask) override;
+  void stencilMask(GLuint mask) override;
+  void stencilMaskSeparate(GLenum face, GLuint mask) override;
+  void stencilOp(GLenum fail, GLenum zfail, GLenum zpass) override;
+  void stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass) override;
+  void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                  GLint border, GLenum format, GLenum type,
+                  const Uint8Array* const pixels) override;
+  void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                  GLsizei depth, GLint border, GLenum format, GLenum type,
+                  const Uint8Array& pixels) override;
+  void texParameterf(GLenum target, GLenum pname, GLfloat param) override;
+  void texParameteri(GLenum target, GLenum pname, GLint param) override;
+  void texStorage3D(GLenum target, GLint levels, GLenum internalformat, GLsizei width,
+                    GLsizei height, GLsizei depth) override;
+  void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+                     GLsizei height, GLenum format, GLenum type, const Uint8Array& pixels) override;
+  void transformFeedbackVaryings(IGLProgram* program, const std::vector<std::string>& varyings,
+                                 GLenum bufferMode) override;
+  void uniform1f(IGLUniformLocation* location, GLfloat v0) override;
+  void uniform1fv(GL::IGLUniformLocation* location, const Float32Array& array) override;
+  void uniform1i(IGLUniformLocation* location, GLint v0) override;
+  void uniform1iv(IGLUniformLocation* location, const Int32Array& v) override;
+  void uniform2f(IGLUniformLocation* location, GLfloat v0, GLfloat v1) override;
+  void uniform2fv(IGLUniformLocation* location, const Float32Array& v) override;
+  void uniform2i(IGLUniformLocation* location, GLint v0, GLint v1) override;
+  void uniform2iv(IGLUniformLocation* location, const Int32Array& v) override;
+  void uniform3f(IGLUniformLocation* location, GLfloat v0, GLfloat v1, GLfloat v2) override;
+  void uniform3fv(IGLUniformLocation* location, const Float32Array& v) override;
+  void uniform3i(IGLUniformLocation* location, GLint v0, GLint v1, GLint v2) override;
+  void uniform3iv(IGLUniformLocation* location, const Int32Array& v) override;
+  void uniform4f(IGLUniformLocation* location, GLfloat v0, GLfloat v1, GLfloat v2,
+                 GLfloat v3) override;
+  void uniform4fv(IGLUniformLocation* location, const Float32Array& v) override;
+  void uniform4i(IGLUniformLocation* location, GLint v0, GLint v1, GLint v2, GLint v3) override;
+  void uniform4iv(IGLUniformLocation* location, const Int32Array& v) override;
+  void uniformBlockBinding(IGLProgram* program, GLuint uniformBlockIndex,
+                           GLuint uniformBlockBinding) override;
+  void uniformMatrix2fv(IGLUniformLocation* location, GLboolean transpose,
+                        const Float32Array& value) override;
+  void uniformMatrix3fv(IGLUniformLocation* location, GLboolean transpose,
+                        const Float32Array& value) override;
+  void uniformMatrix4fv(IGLUniformLocation* location, GLboolean transpose,
+                        const Float32Array& value) override;
+  void uniformMatrix4fv(IGLUniformLocation* location, GLboolean transpose,
+                        const std::array<float, 16>& value) override;
+  void useProgram(IGLProgram* program) override;
+  void validateProgram(IGLProgram* program) override;
+  void vertexAttrib1f(GLuint index, GLfloat v0) override;
+  void vertexAttrib1fv(GLuint indx, Float32Array& values) override;
+  void vertexAttrib2f(GLuint index, GLfloat v0, GLfloat v1) override;
+  void vertexAttrib2fv(GLuint index, Float32Array& values) override;
+  void vertexAttrib3f(GLuint index, GLfloat v0, GLfloat v1, GLfloat v2) override;
+  void vertexAttrib3fv(GLuint index, Float32Array& values) override;
+  void vertexAttrib4f(GLuint index, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3) override;
+  void vertexAttrib4fv(GLuint index, Float32Array& values) override;
+  void vertexAttribDivisor(GLuint index, GLuint divisor) override;
+  void vertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized,
+                           GLint stride, GLintptr offset) override;
+  void viewport(GLint x, GLint y, GLsizei width, GLsizei height) override;
+
+private:
+  std::unordered_map<std::string, GLenum> EnumMap;
+
+}; // end of class GLRenderingContext
+
+} // end of namespace GL
+} // end of namespace BABYLON
+
+#endif // end of BABYLON_IMPL_GL_RENDERING_CONTEXT_H

--- a/src/Standalone_OSX/plist.in
+++ b/src/Standalone_OSX/plist.in
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/src/Standalone_OSX/resources/Main.storyboard
+++ b/src/Standalone_OSX/resources/Main.storyboard
@@ -1,0 +1,720 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="OpenGL Container" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="OpenGL Container" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About OpenGL Container" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide OpenGL Container" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit OpenGL Container" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq"/>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27"/>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq"/>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL"/>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST"/>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                                        <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="OpenGL Container Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="OpenGL Container" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="Pss-Mx-4xx"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hIz-AP-VOD">
+            <objects>
+                <viewController id="XfG-lQ-9wD" sceneMemberID="viewController">
+                    <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="800" height="440"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <containerView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sad-5a-BIl">
+                                <rect key="frame" x="20" y="20" width="760" height="400"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" heightSizable="YES"/>
+                                <connections>
+                                    <segue destination="7pt-A1-x6N" kind="embed" id="cTq-Se-qYn"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
+                    </view>
+                </viewController>
+                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="737"/>
+        </scene>
+        <!--OpenGL View Controller-->
+        <scene sceneID="4ik-eK-sQN">
+            <objects>
+                <viewController id="7pt-A1-x6N" customClass="OpenGLViewController" sceneMemberID="viewController">
+                    <view key="view" id="6ZG-ww-HOb" customClass="OpenGLView">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="Uki-ba-RdS" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-161" y="1401"/>
+        </scene>
+    </scenes>
+</document>

--- a/src/Standalone_OSX/src/BabylonManager.cpp
+++ b/src/Standalone_OSX/src/BabylonManager.cpp
@@ -1,0 +1,43 @@
+#include "BabylonManager.h"
+#include "basic_canvas.h"
+#include "HelloScene.h"
+
+// Babylon
+#include <babylon/engines/engine.h>
+#include <babylon/engines/scene.h>
+
+BabylonManager::BabylonManager(int width, int height):
+  _width(width),
+  _height(height),
+  _renderableScene(nullptr)
+{
+  _renderCanvas = std::make_unique<BasicCanvas>();
+  _renderCanvas->clientWidth = _width;
+  _renderCanvas->clientHeight = _height;
+  _renderCanvas->setFrameSize(_width, _height);
+  
+  _renderableScene = Samples::MakeHelloScene(_renderCanvas.get());
+  _renderableScene->initialize(_renderCanvas.get());
+}
+
+BabylonManager::~BabylonManager()
+{
+}
+
+void BabylonManager::render()
+{
+  // Render Scene
+  _renderableScene->render();
+}
+
+void BabylonManager::setSize(int width, int height)
+{
+  if(_width != width || _height != height)
+  {
+    _width = width;
+    _height = height;
+    
+    _renderCanvas->setFrameSize(_width, _height);
+    _renderableScene->getEngine()->resize();
+  }
+}

--- a/src/Standalone_OSX/src/BabylonView.mm
+++ b/src/Standalone_OSX/src/BabylonView.mm
@@ -1,0 +1,38 @@
+#import "BabylonView.h"
+#import "BabylonManager.h"
+
+@interface BabylonView()
+@property (nonatomic, readonly) BabylonManager* launcher;
+@end
+
+@implementation BabylonView
+
+- (instancetype)initWithSize:(CGSize)size
+{
+  if(self = [super init])
+  {
+    _launcher = new BabylonManager(size.width, size.height);
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  delete _launcher;
+}
+
+- (void)setSize:(CGSize)size
+{
+  _launcher->setSize(size.width, size.height);
+}
+
+- (void)render
+{
+  _launcher->render();
+}
+
+- (void)update
+{
+}
+
+@end

--- a/src/Standalone_OSX/src/HelloScene.cpp
+++ b/src/Standalone_OSX/src/HelloScene.cpp
@@ -1,0 +1,77 @@
+#include "HelloScene.h"
+
+#include <babylon/cameras/free_camera.h>
+#include <babylon/lights/hemispheric_light.h>
+#include <babylon/meshes/mesh.h>
+
+#include <babylon/engines/scene.h>
+#include <babylon/maths/color4.h>
+
+#include <babylon/cameras/arc_rotate_camera.h>
+#include <babylon/materials/standard_material.h>
+#include <babylon/materials/textures/mirror_texture.h>
+
+#include <iostream>
+#include <stdexcept>
+
+namespace Samples {
+using namespace BABYLON;
+
+// This files demonstrates how to create a very simple renderable scene
+struct HelloScene : public IRenderableScene
+{
+public:
+  HelloScene(ICanvas* iCanvas) : IRenderableScene(iCanvas)
+  {
+  }
+  
+  const char* getName() override { return "Hello Scene"; }
+
+  void initializeScene(ICanvas* canvas, Scene* scene) override
+  {
+    scene->clearColor = Color4(0.5f, 0.f, 0.f, 1.f);
+    
+    auto camera = ArcRotateCamera::New("camera1", 0.f, 0.f, 10.f, Vector3::Zero(), scene);
+    camera->setPosition(Vector3(0.f, 5.f, -10.f));
+    camera->attachControl(canvas, true);
+
+    camera->upperBetaLimit = Math::PI_2;
+    camera->lowerRadiusLimit = 4.f;
+
+    auto light = HemisphericLight::New("light1", Vector3(0.f, 1.f, 0.f), scene);
+    light->intensity = 0.7f;
+
+    auto knot = Mesh::CreateTorusKnot("knot", 1, 0.4f, 128, 64, 2, 3, scene);
+
+    // Mirror
+    auto mirror = Mesh::CreateBox("Mirror", 1.0, scene);
+    mirror->scaling = Vector3(100.f, 0.01f, 100.f);
+    auto mirrorMaterial = StandardMaterial::New("mirror", scene);
+    auto reflectionTexture = MirrorTexture::New("mirror", 1024.f, scene, true);
+    reflectionTexture->mirrorPlane = Plane(0.f, -1.f, 0.f, -2.f);
+    reflectionTexture->renderList = {knot.get()};
+    reflectionTexture->level = 1.f;
+    reflectionTexture->samples = 16;
+    mirrorMaterial->reflectionTexture = reflectionTexture;
+    mirror->material = mirrorMaterial;
+    mirror->position = Vector3(0.f, -2.f, 0.f);
+
+    // Main material
+    auto mainMaterial = StandardMaterial::New("main", scene);
+    knot->material = mainMaterial;
+    mainMaterial->diffuseColor = Color4(0.2f, 0.4f, 0.8f, 1.f);
+
+    // Fog
+    scene->fogMode  = Scene::FOGMODE_LINEAR;
+    scene->fogColor = scene->clearColor;
+    scene->fogStart = 20.f;
+    scene->fogEnd   = 50.f;
+  }
+};
+
+std::shared_ptr<IRenderableScene> MakeHelloScene(ICanvas* canvas)
+{
+  return std::make_shared<HelloScene>(canvas);
+}
+
+} // end of namespace Samples

--- a/src/Standalone_OSX/src/OpenGLViewController.m
+++ b/src/Standalone_OSX/src/OpenGLViewController.m
@@ -1,0 +1,121 @@
+#import "OpenGLViewController.h"
+#import <Foundation/Foundation.h>
+#include <OpenGL/gl3.h>
+#import "BabylonView.h"
+
+@implementation OpenGLView
+@end
+
+@implementation OpenGLViewController
+{
+  OpenGLView *_view;
+  PlatformGLContext *_context;
+  GLuint _defaultFrameBuffer;
+  CVDisplayLinkRef _displayLink;
+  BabylonView *_babylonView;
+}
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  _view = (OpenGLView *)self.view;
+  [self prepareView];
+  [self makeCurrentContext];
+}
+
+- (CGSize)drawableSize
+{
+  CGSize viewSizePoints = _view.bounds.size;
+  CGSize viewSizePixels = [_view convertSizeToBacking:viewSizePoints];
+  return viewSizePixels;
+}
+
+- (void)makeCurrentContext
+{
+  [_context makeCurrentContext];
+}
+
+static CVReturn OpenGLDisplayLinkCallback(CVDisplayLinkRef displayLink,
+                                         const CVTimeStamp* now,
+                                         const CVTimeStamp* outputTime,
+                                         CVOptionFlags flagsIn,
+                                         CVOptionFlags* flagsOut,
+                                         void* displayLinkContext)
+{
+  OpenGLViewController *viewController = (__bridge OpenGLViewController*)displayLinkContext;
+  [viewController draw];
+  return YES;
+}
+
+- (void)draw
+{
+  CGLLockContext(_context.CGLContextObj);
+  [_context makeCurrentContext];
+  
+  [_babylonView render];
+  
+  CGLFlushDrawable(_context.CGLContextObj);
+  CGLUnlockContext(_context.CGLContextObj);
+}
+
+- (void)prepareView
+{
+  NSOpenGLPixelFormatAttribute attrs[] =
+  {
+    NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core,
+    NSOpenGLPFAColorSize, 24,
+    NSOpenGLPFAAlphaSize, 8,
+    NSOpenGLPFADepthSize, 24,
+    NSOpenGLPFADoubleBuffer,
+    NSOpenGLPFAAccelerated ,
+    0
+  };
+  
+  NSOpenGLPixelFormat *pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs];
+  NSAssert(pixelFormat, @"No OpenGL pixel format");
+  _context = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
+  CGLLockContext(_context.CGLContextObj);
+  [_context makeCurrentContext];
+  CGLUnlockContext(_context.CGLContextObj);
+
+  _view.pixelFormat = pixelFormat;
+  _view.openGLContext = _context;
+  _view.wantsBestResolutionOpenGLSurface = YES;
+  
+  // Default FBO is 0 on macOS since it uses a traditional OpenGL pixel format model
+  _defaultFrameBuffer = 0;
+  CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
+  // Set the renderer output callback function
+  CVDisplayLinkSetOutputCallback(_displayLink, &OpenGLDisplayLinkCallback, (__bridge void*)self);
+  CVDisplayLinkSetCurrentCGDisplayFromOpenGLContext(_displayLink, _context.CGLContextObj, pixelFormat.CGLPixelFormatObj);
+  
+  _babylonView = [[BabylonView alloc] initWithSize:[self drawableSize]];
+}
+
+- (void)viewDidLayout
+{
+  CGLLockContext(_context.CGLContextObj);
+  [self makeCurrentContext];
+
+  // Update size to Babylon
+  [_babylonView setSize:[self drawableSize]];
+
+  CGLUnlockContext(_context.CGLContextObj);
+  if(!CVDisplayLinkIsRunning(_displayLink))
+  {
+    CVDisplayLinkStart(_displayLink);
+  }
+}
+
+- (void)viewWillDisappear
+{
+  CVDisplayLinkStop(_displayLink);
+}
+
+- (void)dealloc
+{
+  CVDisplayLinkStop(_displayLink);
+  CVDisplayLinkRelease(_displayLink);
+}
+
+@end

--- a/src/Standalone_OSX/src/basic_canvas.cpp
+++ b/src/Standalone_OSX/src/basic_canvas.cpp
@@ -1,0 +1,42 @@
+#include "basic_canvas.h"
+#include "gl_rendering_context.h"
+
+using namespace BABYLON;
+
+BasicCanvas::BasicCanvas() : ICanvas{}
+{
+  _renderingContext          = std::make_unique<GL::GLRenderingContext>();
+  _boundingClientRect.bottom = clientHeight;
+  _boundingClientRect.height = clientHeight;
+  _boundingClientRect.left   = 0;
+  _boundingClientRect.right  = clientWidth;
+  _boundingClientRect.top    = 0;
+  _boundingClientRect.width  = clientWidth;
+}
+
+BasicCanvas::~BasicCanvas()
+{
+}
+
+bool BasicCanvas::initializeContext3d()
+{
+  if (!_initialized) {
+    _initialized = _renderingContext->initialize();
+  }
+  return _initialized;
+}
+
+ClientRect& BasicCanvas::getBoundingClientRect()
+{
+  return _boundingClientRect;
+}
+
+ICanvasRenderingContext2D* BasicCanvas::getContext2d()
+{
+  return nullptr;
+}
+
+GL::IGLRenderingContext* BasicCanvas::getContext3d(const EngineOptions& /*options*/)
+{
+  return _renderingContext.get();
+}

--- a/src/Standalone_OSX/src/gl_rendering_context.cpp
+++ b/src/Standalone_OSX/src/gl_rendering_context.cpp
@@ -1,0 +1,1170 @@
+#include "gl_rendering_context.h"
+
+#include <array>
+#include <OpenGL/gl3.h>
+#include <OpenGL/gl3ext.h>
+
+// Logging
+#include <babylon/core/logging.h>
+
+namespace BABYLON {
+namespace GL {
+
+void MessageCallback(GLenum /*source*/, GLenum type, GLuint /*id*/, GLenum severity,
+                     GLsizei /*length*/, const GLchar* message, const void* /*userParam*/)
+{
+  fprintf(stderr, "GL CALLBACK: %s type = 0x%x, severity = 0x%x, message = %s\n",
+          (type == DEBUG_TYPE_ERROR ? "** GL ERROR **" : ""), type, severity, message);
+}
+
+GLRenderingContext::GLRenderingContext()
+{
+  // Build map of string vs enums
+  // Textures
+  EnumMap["TEXTURE"]   = TEXTURE;
+  EnumMap["TEXTURE0"]  = TEXTURE0;
+  EnumMap["TEXTURE1"]  = TEXTURE1;
+  EnumMap["TEXTURE2"]  = TEXTURE2;
+  EnumMap["TEXTURE3"]  = TEXTURE3;
+  EnumMap["TEXTURE4"]  = TEXTURE4;
+  EnumMap["TEXTURE5"]  = TEXTURE5;
+  EnumMap["TEXTURE6"]  = TEXTURE6;
+  EnumMap["TEXTURE7"]  = TEXTURE7;
+  EnumMap["TEXTURE8"]  = TEXTURE8;
+  EnumMap["TEXTURE9"]  = TEXTURE9;
+  EnumMap["TEXTURE10"] = TEXTURE10;
+  EnumMap["TEXTURE11"] = TEXTURE11;
+  EnumMap["TEXTURE12"] = TEXTURE12;
+  EnumMap["TEXTURE13"] = TEXTURE13;
+  EnumMap["TEXTURE14"] = TEXTURE14;
+  EnumMap["TEXTURE15"] = TEXTURE15;
+  EnumMap["TEXTURE16"] = TEXTURE16;
+  EnumMap["TEXTURE17"] = TEXTURE17;
+  EnumMap["TEXTURE18"] = TEXTURE18;
+  EnumMap["TEXTURE19"] = TEXTURE19;
+  EnumMap["TEXTURE20"] = TEXTURE20;
+  EnumMap["TEXTURE21"] = TEXTURE21;
+  EnumMap["TEXTURE22"] = TEXTURE22;
+  EnumMap["TEXTURE23"] = TEXTURE23;
+  EnumMap["TEXTURE24"] = TEXTURE24;
+  EnumMap["TEXTURE25"] = TEXTURE25;
+  EnumMap["TEXTURE26"] = TEXTURE26;
+  EnumMap["TEXTURE27"] = TEXTURE27;
+  EnumMap["TEXTURE28"] = TEXTURE28;
+  EnumMap["TEXTURE29"] = TEXTURE29;
+  EnumMap["TEXTURE30"] = TEXTURE30;
+  EnumMap["TEXTURE31"] = TEXTURE31;
+  // Color attachments
+  EnumMap["COLOR_ATTACHMENT0"]  = COLOR_ATTACHMENT0;
+  EnumMap["COLOR_ATTACHMENT1"]  = COLOR_ATTACHMENT1;
+  EnumMap["COLOR_ATTACHMENT2"]  = COLOR_ATTACHMENT2;
+  EnumMap["COLOR_ATTACHMENT3"]  = COLOR_ATTACHMENT3;
+  EnumMap["COLOR_ATTACHMENT4"]  = COLOR_ATTACHMENT4;
+  EnumMap["COLOR_ATTACHMENT5"]  = COLOR_ATTACHMENT5;
+  EnumMap["COLOR_ATTACHMENT6"]  = COLOR_ATTACHMENT6;
+  EnumMap["COLOR_ATTACHMENT7"]  = COLOR_ATTACHMENT7;
+  EnumMap["COLOR_ATTACHMENT8"]  = COLOR_ATTACHMENT8;
+  EnumMap["COLOR_ATTACHMENT9"]  = COLOR_ATTACHMENT9;
+  EnumMap["COLOR_ATTACHMENT10"] = COLOR_ATTACHMENT10;
+  EnumMap["COLOR_ATTACHMENT11"] = COLOR_ATTACHMENT11;
+  EnumMap["COLOR_ATTACHMENT12"] = COLOR_ATTACHMENT12;
+  EnumMap["COLOR_ATTACHMENT13"] = COLOR_ATTACHMENT13;
+  EnumMap["COLOR_ATTACHMENT14"] = COLOR_ATTACHMENT14;
+  EnumMap["COLOR_ATTACHMENT15"] = COLOR_ATTACHMENT15;
+  EnumMap["COLOR_ATTACHMENT16"] = COLOR_ATTACHMENT16;
+  EnumMap["COLOR_ATTACHMENT17"] = COLOR_ATTACHMENT17;
+  EnumMap["COLOR_ATTACHMENT18"] = COLOR_ATTACHMENT18;
+  EnumMap["COLOR_ATTACHMENT19"] = COLOR_ATTACHMENT19;
+  EnumMap["COLOR_ATTACHMENT20"] = COLOR_ATTACHMENT20;
+  EnumMap["COLOR_ATTACHMENT21"] = COLOR_ATTACHMENT21;
+  EnumMap["COLOR_ATTACHMENT22"] = COLOR_ATTACHMENT22;
+  EnumMap["COLOR_ATTACHMENT23"] = COLOR_ATTACHMENT23;
+  EnumMap["COLOR_ATTACHMENT24"] = COLOR_ATTACHMENT24;
+  EnumMap["COLOR_ATTACHMENT25"] = COLOR_ATTACHMENT25;
+  EnumMap["COLOR_ATTACHMENT26"] = COLOR_ATTACHMENT26;
+  EnumMap["COLOR_ATTACHMENT27"] = COLOR_ATTACHMENT27;
+  EnumMap["COLOR_ATTACHMENT28"] = COLOR_ATTACHMENT28;
+  EnumMap["COLOR_ATTACHMENT29"] = COLOR_ATTACHMENT29;
+  EnumMap["COLOR_ATTACHMENT30"] = COLOR_ATTACHMENT30;
+  EnumMap["COLOR_ATTACHMENT31"] = COLOR_ATTACHMENT31;
+}
+
+GLRenderingContext::~GLRenderingContext() = default;
+
+std::string GlErrorCodeStr(GLenum error_code)
+{
+  std::string error;
+  switch (error_code) {
+    case GL_INVALID_ENUM:
+      error = "INVALID_ENUM";
+      break;
+    case GL_INVALID_VALUE:
+      error = "INVALID_VALUE";
+      break;
+    case GL_INVALID_OPERATION:
+      error = "INVALID_OPERATION";
+      break;
+    case GL_OUT_OF_MEMORY:
+      error = "OUT_OF_MEMORY";
+      break;
+    case GL_INVALID_FRAMEBUFFER_OPERATION:
+      error = "INVALID_FRAMEBUFFER_OPERATION";
+      break;
+  }
+  return error;
+}
+
+void glad_post_call_callback(const char* name, void* /*funcptr*/, int /*len_args*/, ...)
+{
+  GLenum error_code;
+  error_code = glGetError();
+
+  std::stringstream msg_str;
+  msg_str << "ERROR " << GlErrorCodeStr(error_code) << "(" << error_code << ") in " << name << "\n";
+  if (error_code != GL_NO_ERROR) {
+    fprintf(stderr, "%s", msg_str.str().c_str());
+  }
+}
+
+void glad_pre_call_callback(const char* name, void* /*funcptr*/, int /*len_args*/, ...)
+{
+  std::stringstream msg_str;
+  msg_str << "glad_pre_call_callback " << name << "\n";
+  fprintf(stderr, "%s", msg_str.str().c_str());
+}
+
+bool GLRenderingContext::initialize(bool enableGLDebugging)
+{
+  // Log the GL version
+  BABYLON_LOGF_INFO("GLRenderingContext", "Using GL version: %s", glGetString(GL_VERSION))
+  // Setup OpenGL options
+  glEnable(GL_MULTISAMPLE);
+  return true;
+}
+
+GLenum GLRenderingContext::operator[](const std::string& name)
+{
+  return EnumMap[name];
+}
+
+void GLRenderingContext::activeTexture(GLenum texture)
+{
+  glActiveTexture(texture);
+}
+
+void GLRenderingContext::attachShader(IGLProgram* program, IGLShader* shader)
+{
+  glAttachShader(program->value, shader ? shader->value : 0);
+}
+
+void GLRenderingContext::beginQuery(GLenum target, IGLQuery* query)
+{
+  glBeginQuery(target, query ? query->value : 0);
+}
+
+void GLRenderingContext::beginTransformFeedback(GLenum primitiveMode)
+{
+  glBeginTransformFeedback(primitiveMode);
+}
+
+void GLRenderingContext::bindAttribLocation(IGLProgram* program, GLuint index,
+                                            const std::string& name)
+{
+  glBindAttribLocation(program->value, index, name.c_str());
+}
+
+void GLRenderingContext::bindBuffer(GLenum target, IGLBuffer* buffer)
+{
+  glBindBuffer(target, buffer ? buffer->value : 0);
+}
+
+void GLRenderingContext::bindFramebuffer(GLenum target, IGLFramebuffer* framebuffer)
+{
+  glBindFramebuffer(target, framebuffer ? framebuffer->value : 0);
+}
+
+void GLRenderingContext::bindBufferBase(GLenum target, GLuint index, IGLBuffer* buffer)
+{
+  glBindBufferBase(target, index, buffer ? buffer->value : 0);
+}
+
+void GLRenderingContext::bindRenderbuffer(GLenum target, IGLRenderbuffer* renderbuffer)
+{
+  glBindRenderbuffer(target, renderbuffer ? renderbuffer->value : 0);
+}
+
+void GLRenderingContext::bindTexture(GLenum target, IGLTexture* texture)
+{
+  glBindTexture(target, texture ? texture->value : 0);
+}
+
+void GLRenderingContext::bindTransformFeedback(GLenum target,
+                                               IGLTransformFeedback* transformFeedback)
+{
+  glBindTransformFeedback(target, transformFeedback->value);
+}
+
+void GLRenderingContext::blendColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
+{
+  glBlendColor(red, green, blue, alpha);
+}
+
+void GLRenderingContext::blendEquation(GLenum mode)
+{
+  glBlendEquation(mode);
+}
+
+void GLRenderingContext::blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
+{
+  glBlendEquationSeparate(modeRGB, modeAlpha);
+}
+
+void GLRenderingContext::blendFunc(GLenum sfactor, GLenum dfactor)
+{
+  glBlendFunc(sfactor, dfactor);
+}
+
+void GLRenderingContext::blendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha,
+                                           GLenum dstAlpha)
+{
+  glBlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+}
+
+void GLRenderingContext::blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1,
+                                         GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1,
+                                         GLbitfield mask, GLenum filter)
+{
+  glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+}
+
+void GLRenderingContext::bufferData(GLenum target, GLsizeiptr sizeiptr, GLenum usage)
+{
+  glBufferData(target, sizeiptr >> 32, reinterpret_cast<any>(sizeiptr & 0x0000ffff), usage);
+}
+
+void GLRenderingContext::bufferData(GLenum target, const Float32Array& data, GLenum usage)
+{
+  glBufferData(target, static_cast<GLint>(data.size() * sizeof(GLfloat)), data.data(), usage);
+}
+
+void GLRenderingContext::bufferData(GLenum target, const Int32Array& data, GLenum usage)
+{
+  glBufferData(target, static_cast<GLint>(data.size() * sizeof(int32_t)), data.data(), usage);
+}
+
+void GLRenderingContext::bufferData(GLenum target, const Uint16Array& data, GLenum usage)
+{
+  glBufferData(target, static_cast<GLint>(data.size() * sizeof(uint16_t)), data.data(), usage);
+}
+
+void GLRenderingContext::bufferData(GLenum target, const Uint32Array& data, GLenum usage)
+{
+  glBufferData(target, static_cast<GLint>(data.size() * sizeof(uint32_t)), data.data(), usage);
+}
+
+void GLRenderingContext::bufferSubData(GLenum target, GLintptr offset, const Uint8Array& data)
+{
+  glBufferSubData(target, offset, static_cast<GLint>(data.size() * sizeof(GLbyte)), data.data());
+}
+
+void GLRenderingContext::bufferSubData(GLenum target, GLintptr offset, const Float32Array& data)
+{
+  glBufferSubData(target, offset, static_cast<GLint>(data.size() * sizeof(GLfloat)), data.data());
+}
+
+void GLRenderingContext::bufferSubData(GLenum target, GLintptr offset, Int32Array& data)
+{
+  glBufferSubData(target, offset, static_cast<GLint>(data.size() * sizeof(int32_t)), data.data());
+}
+
+void GLRenderingContext::bindVertexArray(GL::IGLVertexArrayObject* vao)
+{
+  glBindVertexArray(vao ? vao->value : 0);
+}
+
+GLenum GLRenderingContext::checkFramebufferStatus(GLenum target)
+{
+  return glCheckFramebufferStatus(target);
+}
+
+void GLRenderingContext::clear(GLbitfield mask)
+{
+  glClear(mask);
+}
+
+void GLRenderingContext::clearBufferfv(GLenum buffer, GLint drawbuffer,
+                                       const std::vector<GLfloat>& values, GLint /*srcOffset*/)
+{
+  glClearBufferfv(buffer, drawbuffer, values.data());
+}
+
+void GLRenderingContext::clearBufferiv(GLenum buffer, GLint drawbuffer,
+                                       const std::vector<GLint>& values, GLint /*srcOffset*/)
+{
+  glClearBufferiv(buffer, drawbuffer, values.data());
+}
+
+void GLRenderingContext::clearBufferuiv(GLenum buffer, GLint drawbuffer,
+                                        const std::vector<GLuint>& values, GLint /*srcOffset*/)
+{
+  glClearBufferuiv(buffer, drawbuffer, values.data());
+}
+
+void GLRenderingContext::clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth,
+                                       GLint stencil)
+{
+  glClearBufferfi(buffer, drawbuffer, depth, stencil);
+}
+
+void GLRenderingContext::clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
+{
+  glClearColor(red, green, blue, alpha);
+}
+
+void GLRenderingContext::clearDepth(GLclampf depth)
+{
+  glClearDepth(depth);
+}
+
+void GLRenderingContext::clearStencil(GLint stencil)
+{
+  glClearStencil(stencil);
+}
+
+void GLRenderingContext::colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)
+{
+  glColorMask(red, green, blue, alpha);
+}
+
+void GLRenderingContext::compileShader(IGLShader* shader)
+{
+  glCompileShader(shader->value);
+}
+
+void GLRenderingContext::compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
+                                              GLint width, GLint height, GLint border,
+                                              const Uint8Array& pixels)
+{
+  glCompressedTexImage2D(target, level, internalformat, width, height, border,
+                         static_cast<GLint>(pixels.size() * sizeof(GLbyte)), &pixels[0]);
+}
+
+void GLRenderingContext::compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset,
+                                                 GLint yoffset, GLsizei width, GLsizei height,
+                                                 GLenum format, GLsizeiptr size)
+{
+  glCompressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format,
+                            static_cast<GLint>(size >> 32),
+                            reinterpret_cast<const GLint*>(size & 0x0000ffff));
+}
+
+void GLRenderingContext::copyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x,
+                                        GLint y, GLint width, GLint height, GLint border)
+{
+  glCopyTexImage2D(target, level, internalformat, x, y, width, height, border);
+}
+
+void GLRenderingContext::copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                                           GLint x, GLint y, GLint width, GLint height)
+{
+  glCopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
+}
+
+std::shared_ptr<IGLBuffer> GLRenderingContext::createBuffer()
+{
+  GLuint buffer = 0;
+  glGenBuffers(1, &buffer);
+  return std::make_shared<IGLBuffer>(buffer);
+}
+
+IGLFramebufferPtr GLRenderingContext::createFramebuffer()
+{
+  GLuint buffer = 0;
+  glGenFramebuffers(1, &buffer);
+  return std::make_shared<IGLFramebuffer>(buffer);
+}
+
+IGLProgramPtr GLRenderingContext::createProgram()
+{
+  return std::make_shared<IGLProgram>(glCreateProgram());
+}
+
+std::unique_ptr<IGLQuery> GLRenderingContext::createQuery()
+{
+  return std::make_unique<IGLQuery>(0);
+}
+
+IGLRenderbufferPtr GLRenderingContext::createRenderbuffer()
+{
+  GLuint buffer;
+  glGenRenderbuffers(1, &buffer);
+  return std::make_shared<IGLRenderbuffer>(buffer);
+}
+
+IGLShaderPtr GLRenderingContext::createShader(GLenum type)
+{
+  return std::make_shared<IGLShader>(glCreateShader(type));
+}
+
+IGLTexturePtr GLRenderingContext::createTexture()
+{
+  GLuint texture = 0;
+  glGenTextures(1, &texture);
+  return std::make_shared<IGLTexture>(texture);
+}
+
+IGLTransformFeedbackPtr GLRenderingContext::createTransformFeedback()
+{
+  GLuint transformFeedbackArray = 0;
+  glGenTransformFeedbacks(1, &transformFeedbackArray);
+  return std::make_shared<IGLTransformFeedback>(transformFeedbackArray);
+}
+
+IGLVertexArrayObjectPtr GLRenderingContext::createVertexArray()
+{
+  GLuint vertexArray = 0;
+  glGenVertexArrays(1, &vertexArray);
+  return std::make_shared<IGLVertexArrayObject>(vertexArray);
+}
+
+void GLRenderingContext::cullFace(GLenum mode)
+{
+  glCullFace(mode);
+}
+
+void GLRenderingContext::deleteBuffer(IGLBuffer* buffer)
+{
+  glDeleteBuffers(1, &buffer->value);
+  buffer->value = 0;
+}
+
+void GLRenderingContext::deleteFramebuffer(IGLFramebuffer* framebuffer)
+{
+  glDeleteFramebuffers(1, &framebuffer->value);
+  framebuffer->value = 0;
+}
+
+void GLRenderingContext::deleteProgram(IGLProgram* program)
+{
+  glDeleteProgram(program->value);
+}
+
+void GLRenderingContext::deleteQuery(IGLQuery* /*query*/)
+{
+}
+
+void GLRenderingContext::deleteRenderbuffer(IGLRenderbuffer* renderbuffer)
+{
+  glDeleteRenderbuffers(1, &renderbuffer->value);
+  renderbuffer->value = 0;
+}
+
+void GLRenderingContext::deleteShader(IGLShader* shader)
+{
+  glDeleteShader(shader ? shader->value : 0);
+}
+
+void GLRenderingContext::deleteTexture(IGLTexture* texture)
+{
+  glDeleteTextures(1, &texture->value);
+  texture->value = 0;
+}
+
+void GLRenderingContext::deleteTransformFeedback(IGLTransformFeedback* transformFeedback)
+{
+  glDeleteTransformFeedbacks(1, &transformFeedback->value);
+  transformFeedback->value = 0;
+}
+
+void GLRenderingContext::deleteVertexArray(IGLVertexArrayObject* vao)
+{
+  glDeleteVertexArrays(1, &vao->value);
+  vao->value = 0;
+}
+
+void GLRenderingContext::depthFunc(GLenum func)
+{
+  glDepthFunc(func);
+}
+
+void GLRenderingContext::depthMask(GLboolean flag)
+{
+  glDepthMask(flag);
+}
+
+void GLRenderingContext::depthRange(GLclampf zNear, GLclampf zFar)
+{
+  glDepthRangef(zNear, zFar);
+}
+
+void GLRenderingContext::detachShader(IGLProgram* program, IGLShader* shader)
+{
+  glDetachShader(program->value, shader->value);
+}
+
+void GLRenderingContext::disable(GLenum cap)
+{
+  glDisable(cap);
+}
+
+void GLRenderingContext::disableVertexAttribArray(GLuint index)
+{
+  glDisableVertexAttribArray(index);
+}
+
+void GLRenderingContext::drawArrays(GLenum mode, GLint first, GLint count)
+{
+  glDrawArrays(mode, first, count);
+}
+
+void GLRenderingContext::drawArraysInstanced(GLenum mode, GLint first, GLsizei count,
+                                             GLsizei instanceCount)
+{
+  glDrawArraysInstanced(mode, first, count, instanceCount);
+}
+
+void GLRenderingContext::drawBuffers(const std::vector<GLenum>& buffers)
+{
+  auto n = static_cast<GLsizei>(buffers.size());
+  glDrawBuffers(n, &buffers[0]);
+}
+
+void GLRenderingContext::drawElements(GLenum mode, GLint count, GLenum type, GLintptr offset)
+{
+  glDrawElements(mode, count, type, reinterpret_cast<any>(offset));
+}
+
+void GLRenderingContext::drawElementsInstanced(GLenum mode, GLsizei count, GLenum type,
+                                               GLintptr offset, GLsizei instanceCount)
+{
+  glDrawElementsInstanced(mode, count, type, reinterpret_cast<any>(offset), instanceCount);
+}
+
+void GLRenderingContext::enable(GLenum cap)
+{
+  glEnable(cap);
+}
+
+void GLRenderingContext::enableVertexAttribArray(GLuint index)
+{
+  glEnableVertexAttribArray(index);
+}
+
+void GLRenderingContext::endQuery(GLenum target)
+{
+  glEndQuery(target);
+}
+
+void GLRenderingContext::endTransformFeedback()
+{
+  glEndTransformFeedback();
+}
+
+void GLRenderingContext::finish()
+{
+  glFinish();
+}
+
+void GLRenderingContext::flush()
+{
+  glFlush();
+}
+
+void GLRenderingContext::framebufferRenderbuffer(GLenum target, GLenum attachment,
+                                                 GLenum renderbuffertarget,
+                                                 IGLRenderbuffer* renderbuffer)
+{
+  glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer->value);
+}
+
+void GLRenderingContext::framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget,
+                                              IGLTexture* texture, GLint level)
+{
+  glFramebufferTexture2D(target, attachment, textarget, texture->value, level);
+}
+
+void GLRenderingContext::framebufferTextureLayer(GLenum target, GLenum attachment,
+                                                 IGLTexture* texture, GLint level, GLint layer)
+{
+  glFramebufferTextureLayer(target, attachment, texture->value, level, layer);
+}
+
+void GLRenderingContext::framebufferTextureMultiviewOVR(GLenum /*target*/, GLenum /*attachment*/,
+                                                        IGLTexture* /*texture*/, GLint /*level*/,
+                                                        GLint /*baseViewIndex*/, GLint /*numViews*/)
+{
+}
+
+void GLRenderingContext::frontFace(GLenum mode)
+{
+  glFrontFace(mode);
+}
+
+void GLRenderingContext::generateMipmap(GLenum target)
+{
+  glGenerateMipmap(target);
+}
+
+std::vector<IGLShader*> GLRenderingContext::getAttachedShaders(IGLProgram* /*program*/)
+{
+  // Not supported
+  return std::vector<IGLShader*>();
+}
+
+GLint GLRenderingContext::getAttribLocation(IGLProgram* program, const std::string& name)
+{
+  return glGetAttribLocation(program->value, name.c_str());
+}
+
+GL::any GLRenderingContext::getExtension(const std::string& /*name*/)
+{
+  return nullptr;
+}
+
+bool GLRenderingContext::hasExtension(const std::string& /*extension*/)
+{
+  return true;
+}
+
+std::array<int, 3> GLRenderingContext::getScissorBoxParameter()
+{
+  return {{0, 0, 0}};
+}
+
+GLint GLRenderingContext::getParameteri(GLenum pname)
+{
+  GLint parameter = 0;
+  glGetIntegerv(pname, &parameter);
+  return parameter;
+}
+
+GLfloat GLRenderingContext::getParameterf(GLenum pname)
+{
+  GLfloat parameter = 0;
+  glGetFloatv(pname, &parameter);
+  return parameter;
+}
+
+GLboolean GLRenderingContext::getQueryParameterb(IGLQuery* query, GLenum pname)
+{
+  GLuint parameter = 0;
+  glGetQueryObjectuiv(query->value, pname, &parameter);
+  return parameter == GL_TRUE;
+}
+
+GLuint GLRenderingContext::getQueryParameteri(IGLQuery* query, GLenum pname)
+{
+  unsigned int parameter = 0;
+  glGetQueryObjectuiv(query->value, pname, &parameter);
+  return parameter;
+}
+
+std::string GLRenderingContext::getString(GLenum pname)
+{
+  const char* str = reinterpret_cast<const char*>(glGetString(pname));
+  return str ? std::string(str) : "";
+}
+
+GLint GLRenderingContext::getTexParameteri(GLenum pname)
+{
+  GLint parameter = 0;
+  glGetTexParameteriv(GL_TEXTURE_2D, pname, &parameter);
+  return parameter;
+}
+
+GLfloat GLRenderingContext::getTexParameterf(GLenum pname)
+{
+  GLfloat parameter = 0;
+  glGetTexParameterfv(GL_TEXTURE_2D, pname, &parameter);
+  return parameter;
+}
+
+GLenum GLRenderingContext::getError()
+{
+  return glGetError();
+}
+
+const char* GLRenderingContext::getErrorString(GLenum err)
+{
+  switch (err) {
+    case GL_INVALID_ENUM:
+      return "Invalid enum";
+    case GL_INVALID_OPERATION:
+      return "Invalid operation";
+    case GL_INVALID_VALUE:
+      return "Invalid value";
+    case GL_OUT_OF_MEMORY:
+      return "Out of memory";
+    default:
+      return "Unknown error";
+  }
+}
+
+GLint GLRenderingContext::getProgramParameter(IGLProgram* program, GLenum pname)
+{
+  GLint parameter = 0;
+  glGetProgramiv(program->value, pname, &parameter);
+  return parameter;
+}
+
+std::string GLRenderingContext::getProgramInfoLog(IGLProgram* program)
+{
+  GLint k = -1;
+  glGetProgramiv(program->value, GL_INFO_LOG_LENGTH, &k);
+  if (k <= 0) {
+    return "";
+  }
+
+  std::string result;
+  result.reserve(static_cast<size_t>(k + 1));
+  glGetProgramInfoLog(program->value, k, &k, const_cast<char*>(result.c_str()));
+  return result;
+}
+
+GLint GLRenderingContext::getRenderbufferParameter(GLenum target, GLenum pname)
+{
+  GLint params;
+  glGetRenderbufferParameteriv(target, pname, &params);
+  return params;
+}
+
+GLint GLRenderingContext::getShaderParameter(IGLShader* shader, GLenum pname)
+{
+  GLint parameter = 0;
+  glGetShaderiv(shader->value, pname, &parameter);
+  return parameter;
+}
+
+IGLShaderPrecisionFormat* GLRenderingContext::getShaderPrecisionFormat(GLenum /*shadertype*/,
+                                                                       GLenum /*precisiontype*/)
+{
+  return nullptr;
+}
+
+std::string GLRenderingContext::getShaderInfoLog(IGLShader* shader)
+{
+  GLint logSize = -1;
+  glGetShaderiv(shader->value, GL_INFO_LOG_LENGTH, &logSize);
+  if (logSize <= 0) {
+    return "";
+  }
+
+  // The maxLength includes the NULL character
+  auto logSizei = static_cast<GLbitfield>(logSize);
+  std::vector<GLchar> infoLog(logSizei);
+  glGetShaderInfoLog(shader->value, logSize, &logSize, &infoLog[0]);
+  return std::string(infoLog.begin(), infoLog.end());
+}
+
+std::string GLRenderingContext::getShaderSource(IGLShader* shader)
+{
+  GLchar buffer[5000];
+  GLsizei size;
+  glGetShaderSource(shader->value, 5000, &size, &buffer[0]);
+
+  return std::string(buffer, static_cast<std::size_t>(size) + 1);
+}
+
+GLuint GLRenderingContext::getUniformBlockIndex(IGLProgram* program,
+                                                const std::string& uniformBlockName)
+{
+  return glGetUniformBlockIndex(program->value, uniformBlockName.data());
+}
+
+std::unique_ptr<IGLUniformLocation> GLRenderingContext::getUniformLocation(IGLProgram* program,
+                                                                           const std::string& name)
+{
+  GLint value = glGetUniformLocation(program->value, name.c_str());
+  if (value != -1) {
+    return std::make_unique<IGLUniformLocation>(value);
+  }
+
+  return nullptr;
+}
+
+void GLRenderingContext::hint(GLenum target, GLenum mode)
+{
+  glHint(target, mode);
+}
+
+GLboolean GLRenderingContext::isBuffer(IGLBuffer* buffer)
+{
+  return glIsBuffer(buffer->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isEnabled(GLenum cap)
+{
+  return glIsEnabled(cap) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isFramebuffer(IGLFramebuffer* framebuffer)
+{
+  return glIsFramebuffer(framebuffer->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isProgram(IGLProgram* program)
+{
+  return glIsProgram(program->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isRenderbuffer(IGLRenderbuffer* renderbuffer)
+{
+  return glIsRenderbuffer(renderbuffer->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isShader(IGLShader* shader)
+{
+  return glIsShader(shader->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isTexture(IGLTexture* texture)
+{
+  return glIsTexture(texture->value) == GL_TRUE;
+}
+
+void GLRenderingContext::lineWidth(GLfloat width)
+{
+  glLineWidth(width);
+}
+
+bool GLRenderingContext::linkProgram(IGLProgram* program)
+{
+  glLinkProgram(program->value);
+
+  // Test linker result.
+  GLint linkSucceed = GL_FALSE;
+  glGetProgramiv(program->value, GL_LINK_STATUS, &linkSucceed);
+
+  return linkSucceed != GL_FALSE;
+}
+
+void GLRenderingContext::pixelStorei(GLenum pname, GLint param)
+{
+  if (pname != UNPACK_FLIP_Y_WEBGL) {
+    glPixelStorei(pname, param);
+  }
+}
+
+void GLRenderingContext::polygonOffset(GLfloat factor, GLfloat units)
+{
+  glPolygonOffset(factor, units);
+}
+
+void GLRenderingContext::readBuffer(GLenum src)
+{
+  glReadBuffer(src);
+}
+
+void GLRenderingContext::readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format,
+                                    GLenum type, Float32Array& pixels)
+{
+  glReadPixels(x, y, width, height, format, type, &pixels[0]);
+}
+
+void GLRenderingContext::readPixels(GLint x, GLint y, GLint width, GLint height, GLenum format,
+                                    GLenum type, Uint8Array& pixels)
+{
+  glReadPixels(x, y, width, height, format, type, &pixels[0]);
+}
+
+void GLRenderingContext::renderbufferStorage(GLenum target, GLenum internalformat, GLint width,
+                                             GLint height)
+{
+  glRenderbufferStorage(target, internalformat, width, height);
+}
+
+void GLRenderingContext::renderbufferStorageMultisample(GLenum target, GLsizei samples,
+                                                        GLenum internalFormat, GLsizei width,
+                                                        GLsizei height)
+{
+  glRenderbufferStorageMultisample(target, samples, internalFormat, width, height);
+}
+
+void GLRenderingContext::sampleCoverage(GLclampf value, GLboolean invert)
+{
+  glSampleCoverage(value, invert);
+}
+
+void GLRenderingContext::scissor(GLint x, GLint y, GLint width, GLint height)
+{
+  glScissor(x, y, width, height);
+}
+
+void GLRenderingContext::shaderSource(IGLShader* shader, const std::string& source)
+{
+  auto length        = static_cast<int>(source.length());
+  const GLchar* line = source.c_str();
+  glShaderSource(shader->value, 1, &line, &length);
+}
+
+void GLRenderingContext::stencilFunc(GLenum func, GLint ref, GLuint mask)
+{
+  glStencilFunc(func, ref, mask);
+}
+
+void GLRenderingContext::stencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask)
+{
+  glStencilFuncSeparate(face, func, ref, mask);
+}
+
+void GLRenderingContext::stencilMask(GLuint mask)
+{
+  glStencilMask(mask);
+}
+
+void GLRenderingContext::stencilMaskSeparate(GLenum face, GLuint mask)
+{
+  glStencilMaskSeparate(face, mask);
+}
+
+void GLRenderingContext::stencilOp(GLenum fail, GLenum zfail, GLenum zpass)
+{
+  glStencilOp(fail, zfail, zpass);
+}
+
+void GLRenderingContext::stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass)
+{
+  glStencilOpSeparate(face, fail, zfail, zpass);
+}
+
+void GLRenderingContext::texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width,
+                                    GLsizei height, GLint border, GLenum format, GLenum type,
+                                    const Uint8Array* const pixels)
+{
+  if (pixels == nullptr) {
+    glTexImage2D(target, level, internalformat, width, height, border, format, type, nullptr);
+  }
+  else {
+    glTexImage2D(target, level, internalformat, width, height, border, format, type,
+                 pixels->data());
+  }
+}
+
+void GLRenderingContext::texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width,
+                                    GLsizei height, GLsizei depth, GLint border, GLenum format,
+                                    GLenum type, const Uint8Array& pixels)
+{
+  glTexImage3D(target, level, internalformat, width, height, depth, border, format, type,
+               &pixels[0]);
+}
+
+void GLRenderingContext::texParameterf(GLenum target, GLenum pname, GLfloat param)
+{
+  glTexParameterf(target, pname, param);
+}
+
+void GLRenderingContext::texParameteri(GLenum target, GLenum pname, GLint param)
+{
+  glTexParameteri(target, pname, param);
+}
+
+void GLRenderingContext::texStorage3D(GLenum target, GLint levels, GLenum internalformat,
+                                      GLsizei width, GLsizei height, GLsizei depth)
+{
+  glTexStorage3D(target, levels, internalformat, width, height, depth);
+}
+
+void GLRenderingContext::texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                                       GLint width, GLint height, GLenum format, GLenum type,
+                                       const Uint8Array& pixels)
+{
+  glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, &pixels[0]);
+}
+
+void GLRenderingContext::transformFeedbackVaryings(IGLProgram* program,
+                                                   const std::vector<std::string>& varyings,
+                                                   GLenum bufferMode)
+{
+  std::vector<const char*> _varyings;
+  for (auto varying : varyings) {
+    _varyings.emplace_back(varying.c_str());
+  }
+
+  glTransformFeedbackVaryings(program->value, static_cast<int>(varyings.size()), &_varyings[0],
+                              bufferMode);
+}
+
+void GLRenderingContext::uniform1f(IGLUniformLocation* location, GLfloat x)
+{
+  glUniform1f(location->value, x);
+}
+
+void GLRenderingContext::GLRenderingContext::uniform1fv(GL::IGLUniformLocation* uniform,
+                                                        const Float32Array& array)
+{
+  glUniform1fv(uniform->value, static_cast<int>(array.size() * sizeof(GLfloat)), array.data());
+}
+
+void GLRenderingContext::uniform1i(IGLUniformLocation* location, GLint x)
+{
+  glUniform1i(location->value, x);
+}
+
+void GLRenderingContext::uniform1iv(IGLUniformLocation* location, const Int32Array& v)
+{
+  glUniform1iv(location->value, static_cast<GLint>(v.size() * sizeof(int32_t)), v.data());
+}
+
+void GLRenderingContext::uniform2f(IGLUniformLocation* location, GLfloat x, GLfloat y)
+{
+  glUniform2f(location->value, x, y);
+}
+
+void GLRenderingContext::uniform2fv(IGLUniformLocation* location, const Float32Array& v)
+{
+  glUniform2fv(location->value, static_cast<GLint>(v.size() * sizeof(GLfloat)), v.data());
+}
+
+void GLRenderingContext::uniform2i(IGLUniformLocation* location, GLint x, GLint y)
+{
+  glUniform2i(location->value, x, y);
+}
+
+void GLRenderingContext::uniform2iv(IGLUniformLocation* location, const Int32Array& v)
+{
+  glUniform2iv(location->value, static_cast<GLint>(v.size() * sizeof(int32_t)), v.data());
+}
+
+void GLRenderingContext::uniform3f(IGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z)
+{
+  glUniform3f(location->value, x, y, z);
+}
+
+void GLRenderingContext::uniform3fv(IGLUniformLocation* location, const Float32Array& v)
+{
+  glUniform3fv(location->value, static_cast<GLint>(v.size() * sizeof(GLfloat)), v.data());
+}
+
+void GLRenderingContext::uniform3i(IGLUniformLocation* location, GLint x, GLint y, GLint z)
+{
+  glUniform3i(location->value, x, y, z);
+}
+
+void GLRenderingContext::uniform3iv(IGLUniformLocation* location, const Int32Array& v)
+{
+  glUniform3iv(location->value, static_cast<GLint>(v.size() * sizeof(int32_t)), v.data());
+}
+
+void GLRenderingContext::uniform4f(IGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z,
+                                   GLfloat w)
+{
+  glUniform4f(location->value, x, y, z, w);
+}
+
+void GLRenderingContext::uniform4fv(IGLUniformLocation* location, const Float32Array& v)
+{
+  glUniform4fv(location->value, static_cast<GLint>(v.size() * sizeof(GLfloat)), v.data());
+}
+
+void GLRenderingContext::uniform4i(IGLUniformLocation* location, GLint x, GLint y, GLint z, GLint w)
+{
+  glUniform4i(location->value, x, y, z, w);
+}
+
+void GLRenderingContext::uniform4iv(IGLUniformLocation* location, const Int32Array& v)
+{
+  glUniform4iv(location->value, static_cast<GLint>(v.size() * sizeof(int32_t)), v.data());
+}
+
+void GLRenderingContext::uniformBlockBinding(IGLProgram* program, GLuint uniformBlockIndex,
+                                             GLuint uniformBlockBinding)
+{
+  glUniformBlockBinding(program->value, uniformBlockIndex, uniformBlockBinding);
+}
+
+void GLRenderingContext::uniformMatrix2fv(IGLUniformLocation* location, GLboolean transpose,
+                                          const Float32Array& value)
+{
+  glUniformMatrix2fv(location->value, static_cast<GLint>(value.size() / 16), transpose,
+                     value.data());
+}
+
+void GLRenderingContext::uniformMatrix3fv(IGLUniformLocation* location, GLboolean transpose,
+                                          const Float32Array& value)
+{
+  glUniformMatrix3fv(location->value, static_cast<GLint>(value.size() / 16), transpose,
+                     value.data());
+}
+
+void GLRenderingContext::uniformMatrix4fv(IGLUniformLocation* location, GLboolean transpose,
+                                          const Float32Array& value)
+{
+  glUniformMatrix4fv(location->value, static_cast<GLint>(value.size() / 16), transpose,
+                     value.data());
+}
+
+void GLRenderingContext::uniformMatrix4fv(IGLUniformLocation* location, GLboolean transpose,
+                                          const std::array<float, 16>& value)
+{
+  glUniformMatrix4fv(location->value, static_cast<GLint>(value.size() / 16), transpose,
+                     value.data());
+}
+
+void GLRenderingContext::useProgram(IGLProgram* program)
+{
+  glUseProgram(program->value);
+}
+
+void GLRenderingContext::validateProgram(IGLProgram* program)
+{
+  glValidateProgram(program->value);
+}
+
+void GLRenderingContext::vertexAttrib1f(GLuint indx, GLfloat x)
+{
+  glVertexAttrib1f(indx, x);
+}
+
+void GLRenderingContext::vertexAttrib1fv(GLuint indx, Float32Array& values)
+{
+  glVertexAttrib1fv(indx, values.data());
+}
+
+void GLRenderingContext::vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y)
+{
+  glVertexAttrib2f(indx, x, y);
+}
+
+void GLRenderingContext::vertexAttrib2fv(GLuint indx, Float32Array& values)
+{
+  glVertexAttrib2fv(indx, values.data());
+}
+
+void GLRenderingContext::vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z)
+{
+  glVertexAttrib3f(indx, x, y, z);
+}
+
+void GLRenderingContext::vertexAttrib3fv(GLuint indx, Float32Array& values)
+{
+  glVertexAttrib3fv(indx, values.data());
+}
+
+void GLRenderingContext::vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w)
+{
+  glVertexAttrib4f(indx, x, y, z, w);
+}
+
+void GLRenderingContext::vertexAttrib4fv(GLuint indx, Float32Array& values)
+{
+  glVertexAttrib4fv(indx, values.data());
+}
+
+void GLRenderingContext::vertexAttribDivisor(GLuint index, GLuint divisor)
+{
+  glVertexAttribDivisor(index, divisor);
+}
+
+void GLRenderingContext::vertexAttribPointer(GLuint indx, GLint size, GLenum type,
+                                             GLboolean normalized, GLint stride, GLintptr offset)
+{
+  glVertexAttribPointer(indx, size, type, normalized, stride, reinterpret_cast<any>(offset));
+}
+
+void GLRenderingContext::viewport(GLint x, GLint y, GLint width, GLint height)
+{
+  glViewport(x, y, width, height);
+}
+
+} // end of namespace GL
+} // end of namespace BABYLON

--- a/src/Standalone_OSX/src/main.m
+++ b/src/Standalone_OSX/src/main.m
@@ -1,0 +1,6 @@
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, const char * argv[])
+{
+    return NSApplicationMain(argc, argv);
+}

--- a/src/Standalone_iOS/CMakeLists.txt
+++ b/src/Standalone_iOS/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Configure build environment
+include(../../cmake/BuildEnvironment.cmake)
+
+# Target name
+set(TARGET Standalone_iOS)
+
+# Sources
+file(GLOB HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/*.*)
+file(GLOB SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.*)
+file(GLOB RESOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/resources/*.*)
+
+set(STORYBOARD_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources/Main.storyboard
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources/LaunchScreen.storyboard)
+
+babylon_add_executable(${TARGET} ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})
+
+target_include_directories(${TARGET} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_link_libraries(${TARGET} PRIVATE
+    BabylonCpp
+    MaterialsLibrary
+    # TODO: Fix issue when setting to static for iOS
+    # ProceduralTexturesLibrary
+    json_hpp
+)
+
+target_compile_definitions(${TARGET} PRIVATE GLES_SILENCE_DEPRECATION GLES3=1)
+
+set_target_properties(${TARGET} PROPERTIES
+    MACOSX_BUNDLE true
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_LIST_DIR}/plist.in"
+    XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET 12.0
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.BabylonCpp.Standalone.iOS"
+    XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
+    XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES YES
+    XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
+    RESOURCE "${STORYBOARD_FILES}"
+)

--- a/src/Standalone_iOS/include/AppDelegate.h
+++ b/src/Standalone_iOS/include/AppDelegate.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@property (strong, nonatomic) UIWindow *window;
+@end

--- a/src/Standalone_iOS/include/BabylonManager.h
+++ b/src/Standalone_iOS/include/BabylonManager.h
@@ -1,0 +1,29 @@
+#ifndef BABYLON_MANAGER_H
+#define BABYLON_MANAGER_H
+
+#include <memory>
+
+namespace BABYLON {
+class IRenderableScene;
+}
+
+class BasicCanvas;
+
+class BabylonManager {
+public:
+  int _width = 0;
+  int _height = 0;
+  
+  BabylonManager(int width, int height);
+  ~BabylonManager();
+  
+  void render();
+  void setSize(int width, int height);
+  
+private:
+  // Babylon scene related variables
+  std::unique_ptr<BasicCanvas> _renderCanvas;
+  std::shared_ptr<BABYLON::IRenderableScene> _renderableScene;
+}; // end of class BABYLON_MANAGER_H
+
+#endif

--- a/src/Standalone_iOS/include/BabylonView.h
+++ b/src/Standalone_iOS/include/BabylonView.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+@interface BabylonView : NSObject
+
+- (instancetype)initWithSize:(CGSize)size;
+- (void)setSize:(CGSize)size;
+- (void)render;
+- (void)update;
+
+@end

--- a/src/Standalone_iOS/include/HelloScene.h
+++ b/src/Standalone_iOS/include/HelloScene.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <memory>
+#include <babylon/interfaces/icanvas.h>
+#include <babylon/interfaces/irenderable_scene.h>
+
+namespace Samples {
+
+// This files demonstrates how to create a very simple renderable scene
+std::shared_ptr<BABYLON::IRenderableScene> MakeHelloScene(BABYLON::ICanvas* canvas);
+} // end of namespace Samples

--- a/src/Standalone_iOS/include/OpenGLViewController.h
+++ b/src/Standalone_iOS/include/OpenGLViewController.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+@interface OpenGLView : UIView
+
+@end
+
+@interface OpenGLViewController : UIViewController
+
+@end

--- a/src/Standalone_iOS/include/basic_canvas.h
+++ b/src/Standalone_iOS/include/basic_canvas.h
@@ -1,0 +1,18 @@
+#ifndef BABYLON_BASIC_CANVAS_H
+#define BABYLON_BASIC_CANVAS_H
+
+#include <babylon/interfaces/icanvas.h>
+
+class BasicCanvas : public BABYLON::ICanvas {
+
+public:
+  BasicCanvas();
+  virtual ~BasicCanvas();
+
+  BABYLON::ClientRect& getBoundingClientRect() override;
+  bool initializeContext3d() override;
+  BABYLON::ICanvasRenderingContext2D* getContext2d() override;
+  BABYLON::GL::IGLRenderingContext* getContext3d(const BABYLON::EngineOptions& options) override;
+};
+
+#endif // BABYLON_BASIC_CANVAS_H

--- a/src/Standalone_iOS/include/gl_rendering_context.h
+++ b/src/Standalone_iOS/include/gl_rendering_context.h
@@ -1,0 +1,235 @@
+#ifndef BABYLON_IMPL_GL_RENDERING_CONTEXT_H
+#define BABYLON_IMPL_GL_RENDERING_CONTEXT_H
+
+#include <babylon/babylon_api.h>
+#include <babylon/interfaces/igl_rendering_context.h>
+#include <unordered_map>
+
+namespace BABYLON {
+namespace GL {
+
+class GLRenderingContext : public BABYLON::GL::IGLRenderingContext {
+
+public:
+  GLRenderingContext();
+  ~GLRenderingContext() override; // = default
+
+  bool initialize(bool enableGLDebugging = false) override;
+  GLenum operator[](const std::string& name) override;
+  void activeTexture(GLenum texture) override;
+  void attachShader(IGLProgram* program, IGLShader* shader) override;
+  void beginQuery(GLenum target, IGLQuery* query) override;
+  void beginTransformFeedback(GLenum primitiveMode) override;
+  void bindAttribLocation(IGLProgram* program, GLuint index, const std::string& name) override;
+  void bindBuffer(GLenum target, IGLBuffer* buffer) override;
+  void bindFramebuffer(GLenum target, IGLFramebuffer* framebuffer) override;
+  void bindBufferBase(GLenum target, GLuint index, IGLBuffer* buffer) override;
+  void bindRenderbuffer(GLenum target, IGLRenderbuffer* renderbuffer) override;
+  void bindTexture(GLenum target, IGLTexture* texture) override;
+  void bindTransformFeedback(GLenum target, IGLTransformFeedback* transformFeedback) override;
+  void blendColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) override;
+  void blendEquation(GLenum mode) override;
+  void blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha) override;
+  void blendFunc(GLenum sfactor, GLenum dfactor) override;
+  void blendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha) override;
+  void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
+                       GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter) override;
+  void bufferData(GLenum target, GLsizeiptr size, GLenum usage) override;
+  void bufferData(GLenum target, const Float32Array& data, GLenum usage) override;
+  void bufferData(GLenum target, const Int32Array& data, GLenum usage) override;
+  void bufferData(GLenum target, const Uint16Array& data, GLenum usage) override;
+  void bufferData(GLenum target, const Uint32Array& data, GLenum usage) override;
+  void bufferSubData(GLenum target, GLintptr offset, const Uint8Array& data) override;
+  void bufferSubData(GLenum target, GLintptr offset, const Float32Array& data) override;
+  void bufferSubData(GLenum target, GLintptr offset, Int32Array& data) override;
+  void bindVertexArray(GL::IGLVertexArrayObject* vao) override;
+  GLenum checkFramebufferStatus(GLenum target) override;
+  void clear(GLbitfield mask) override;
+  void clearBufferfv(GLenum buffer, GLint drawbuffer, const std::vector<GLfloat>& values,
+                     GLint srcOffset = 0) override;
+  void clearBufferiv(GLenum buffer, GLint drawbuffer, const std::vector<GLint>& values,
+                     GLint srcOffset = 0) override;
+  void clearBufferuiv(GLenum buffer, GLint drawbuffer, const std::vector<GLuint>& values,
+                      GLint srcOffset = 0) override;
+  void clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil) override;
+  void clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) override;
+  void clearDepth(GLclampf depth) override;
+  void clearStencil(GLint stencil) override;
+  void colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) override;
+  void compileShader(IGLShader* shader) override;
+  void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
+                            GLsizei height, GLint border, const Uint8Array& pixels) override;
+  void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                               GLsizei width, GLsizei height, GLenum format,
+                               GLsizeiptr size) override;
+  void copyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y,
+                      GLsizei width, GLsizei height, GLint border) override;
+  void copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y,
+                         GLint width, GLint height) override;
+  std::shared_ptr<IGLBuffer> createBuffer() override;
+  IGLFramebufferPtr createFramebuffer() override;
+  IGLProgramPtr createProgram() override;
+  std::unique_ptr<IGLQuery> createQuery() override;
+  IGLRenderbufferPtr createRenderbuffer() override;
+  IGLShaderPtr createShader(GLenum type) override;
+  IGLTexturePtr createTexture() override;
+  IGLTransformFeedbackPtr createTransformFeedback() override;
+  IGLVertexArrayObjectPtr createVertexArray() override;
+  void cullFace(GLenum mode) override;
+  void deleteBuffer(IGLBuffer* buffer) override;
+  void deleteFramebuffer(IGLFramebuffer* framebuffer) override;
+  void deleteProgram(IGLProgram* program) override;
+  void deleteQuery(IGLQuery* query) override;
+  void deleteRenderbuffer(IGLRenderbuffer* renderbuffer) override;
+  void deleteShader(IGLShader* shader) override;
+  void deleteTexture(IGLTexture* texture) override;
+  void deleteTransformFeedback(IGLTransformFeedback* transformFeedback) override;
+  void deleteVertexArray(IGLVertexArrayObject* vao) override;
+  void depthFunc(GLenum func) override;
+  void depthMask(GLboolean flag) override;
+  void depthRange(GLclampf zNear, GLclampf zFar) override;
+  void detachShader(IGLProgram* program, IGLShader* shader) override;
+  void disable(GLenum cap) override;
+  void disableVertexAttribArray(GLuint index) override;
+  void drawArrays(GLenum mode, GLint first, GLint count) override;
+  void drawArraysInstanced(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount) override;
+  void drawBuffers(const std::vector<GLenum>& buffers) override;
+  void drawElements(GLenum mode, GLsizei count, GLenum type, GLintptr offset) override;
+  void drawElementsInstanced(GLenum mode, GLsizei count, GLenum type, GLintptr offset,
+                             GLsizei instanceCount) override;
+  void enable(GLenum cap) override;
+  void enableVertexAttribArray(GLuint index) override;
+  void endQuery(GLenum target) override;
+  void endTransformFeedback() override;
+  void finish() override;
+  void flush() override;
+  void framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget,
+                               IGLRenderbuffer* renderbuffer) override;
+  void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, IGLTexture* texture,
+                            GLint level) override;
+  void framebufferTextureLayer(GLenum target, GLenum attachment, IGLTexture* texture, GLint level,
+                               GLint layer) override;
+  void framebufferTextureMultiviewOVR(GLenum target, GLenum attachment, IGLTexture* texture,
+                                      GLint level, GLint baseViewIndex, GLint numViews) override;
+  void frontFace(GLenum mode) override;
+  void generateMipmap(GLenum target) override;
+  std::vector<IGLShader*> getAttachedShaders(IGLProgram* program) override;
+  GLint getAttribLocation(IGLProgram* program, const std::string& name) override;
+  GL::any getExtension(const std::string& name) override;
+  GLboolean hasExtension(const std::string& extension) override;
+  std::array<int, 3> getScissorBoxParameter() override; // GL::SCISSOR_BOX
+  GLint getParameteri(GLenum pname) override;
+  GLfloat getParameterf(GLenum pname) override;
+  GLboolean getQueryParameterb(IGLQuery* query, GLenum pname) override;
+  GLuint getQueryParameteri(IGLQuery* query, GLenum pname) override;
+  std::string getString(GLenum pname) override;
+  GLint getTexParameteri(GLenum pname) override;
+  GLfloat getTexParameterf(GLenum pname) override;
+  GLenum getError() override;
+  const char* getErrorString(GLenum err) override;
+  GLint getProgramParameter(IGLProgram* program, GLenum pname) override;
+  std::string getProgramInfoLog(IGLProgram* program) override;
+  GLint getRenderbufferParameter(GLenum target, GLenum pname) override;
+  std::string getShaderInfoLog(IGLShader* shader) override;
+  GLint getShaderParameter(IGLShader* shader, GLenum pname) override;
+  IGLShaderPrecisionFormat* getShaderPrecisionFormat(GLenum shadertype,
+                                                     GLenum precisiontype) override;
+  std::string getShaderSource(IGLShader* shader) override;
+  GLuint getUniformBlockIndex(IGLProgram* program, const std::string& uniformBlockName) override;
+  std::unique_ptr<IGLUniformLocation> getUniformLocation(IGLProgram* program,
+                                                         const std::string& name) override;
+  void hint(GLenum target, GLenum mode) override;
+  GLboolean isBuffer(IGLBuffer* buffer) override;
+  GLboolean isEnabled(GLenum cap) override;
+  GLboolean isFramebuffer(IGLFramebuffer* framebuffer) override;
+  GLboolean isProgram(IGLProgram* program) override;
+  GLboolean isRenderbuffer(IGLRenderbuffer* renderbuffer) override;
+  GLboolean isShader(IGLShader* shader) override;
+  GLboolean isTexture(IGLTexture* texture) override;
+  void lineWidth(GLfloat width) override;
+  bool linkProgram(IGLProgram* program) override;
+  void pixelStorei(GLenum pname, GLint param) override;
+  void polygonOffset(GLfloat factor, GLfloat units) override;
+  void readBuffer(GLenum src) override;
+  void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+                  Float32Array& pixels) override;
+  void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+                  Uint8Array& pixels) override;
+  void renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width,
+                           GLsizei height) override;
+  void renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalFormat,
+                                      GLsizei width, GLsizei height) override;
+  void sampleCoverage(GLclampf value, GLboolean invert) override;
+  void scissor(GLint x, GLint y, GLsizei width, GLsizei height) override;
+  void shaderSource(IGLShader* shader, const std::string& source) override;
+  void stencilFunc(GLenum func, GLint ref, GLuint mask) override;
+  void stencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask) override;
+  void stencilMask(GLuint mask) override;
+  void stencilMaskSeparate(GLenum face, GLuint mask) override;
+  void stencilOp(GLenum fail, GLenum zfail, GLenum zpass) override;
+  void stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass) override;
+  void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                  GLint border, GLenum format, GLenum type,
+                  const Uint8Array* const pixels) override;
+  void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                  GLsizei depth, GLint border, GLenum format, GLenum type,
+                  const Uint8Array& pixels) override;
+  void texParameterf(GLenum target, GLenum pname, GLfloat param) override;
+  void texParameteri(GLenum target, GLenum pname, GLint param) override;
+  void texStorage3D(GLenum target, GLint levels, GLenum internalformat, GLsizei width,
+                    GLsizei height, GLsizei depth) override;
+  void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+                     GLsizei height, GLenum format, GLenum type, const Uint8Array& pixels) override;
+  void transformFeedbackVaryings(IGLProgram* program, const std::vector<std::string>& varyings,
+                                 GLenum bufferMode) override;
+  void uniform1f(IGLUniformLocation* location, GLfloat v0) override;
+  void uniform1fv(GL::IGLUniformLocation* location, const Float32Array& array) override;
+  void uniform1i(IGLUniformLocation* location, GLint v0) override;
+  void uniform1iv(IGLUniformLocation* location, const Int32Array& v) override;
+  void uniform2f(IGLUniformLocation* location, GLfloat v0, GLfloat v1) override;
+  void uniform2fv(IGLUniformLocation* location, const Float32Array& v) override;
+  void uniform2i(IGLUniformLocation* location, GLint v0, GLint v1) override;
+  void uniform2iv(IGLUniformLocation* location, const Int32Array& v) override;
+  void uniform3f(IGLUniformLocation* location, GLfloat v0, GLfloat v1, GLfloat v2) override;
+  void uniform3fv(IGLUniformLocation* location, const Float32Array& v) override;
+  void uniform3i(IGLUniformLocation* location, GLint v0, GLint v1, GLint v2) override;
+  void uniform3iv(IGLUniformLocation* location, const Int32Array& v) override;
+  void uniform4f(IGLUniformLocation* location, GLfloat v0, GLfloat v1, GLfloat v2,
+                 GLfloat v3) override;
+  void uniform4fv(IGLUniformLocation* location, const Float32Array& v) override;
+  void uniform4i(IGLUniformLocation* location, GLint v0, GLint v1, GLint v2, GLint v3) override;
+  void uniform4iv(IGLUniformLocation* location, const Int32Array& v) override;
+  void uniformBlockBinding(IGLProgram* program, GLuint uniformBlockIndex,
+                           GLuint uniformBlockBinding) override;
+  void uniformMatrix2fv(IGLUniformLocation* location, GLboolean transpose,
+                        const Float32Array& value) override;
+  void uniformMatrix3fv(IGLUniformLocation* location, GLboolean transpose,
+                        const Float32Array& value) override;
+  void uniformMatrix4fv(IGLUniformLocation* location, GLboolean transpose,
+                        const Float32Array& value) override;
+  void uniformMatrix4fv(IGLUniformLocation* location, GLboolean transpose,
+                        const std::array<float, 16>& value) override;
+  void useProgram(IGLProgram* program) override;
+  void validateProgram(IGLProgram* program) override;
+  void vertexAttrib1f(GLuint index, GLfloat v0) override;
+  void vertexAttrib1fv(GLuint indx, Float32Array& values) override;
+  void vertexAttrib2f(GLuint index, GLfloat v0, GLfloat v1) override;
+  void vertexAttrib2fv(GLuint index, Float32Array& values) override;
+  void vertexAttrib3f(GLuint index, GLfloat v0, GLfloat v1, GLfloat v2) override;
+  void vertexAttrib3fv(GLuint index, Float32Array& values) override;
+  void vertexAttrib4f(GLuint index, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3) override;
+  void vertexAttrib4fv(GLuint index, Float32Array& values) override;
+  void vertexAttribDivisor(GLuint index, GLuint divisor) override;
+  void vertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized,
+                           GLint stride, GLintptr offset) override;
+  void viewport(GLint x, GLint y, GLsizei width, GLsizei height) override;
+
+private:
+  std::unordered_map<std::string, GLenum> EnumMap;
+
+}; // end of class GLRenderingContext
+
+} // end of namespace GL
+} // end of namespace BABYLON
+
+#endif // end of BABYLON_IMPL_GL_RENDERING_CONTEXT_H

--- a/src/Standalone_iOS/plist.in
+++ b/src/Standalone_iOS/plist.in
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UIStatusBarHidden</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/src/Standalone_iOS/resources/LaunchScreen.storyboard
+++ b/src/Standalone_iOS/resources/LaunchScreen.storyboard
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14111" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="7Ya-Z8-xQs">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="Jhi-7p-v3R"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-89" y="115"/>
+        </scene>
+    </scenes>
+</document>

--- a/src/Standalone_iOS/resources/Main.storyboard
+++ b/src/Standalone_iOS/resources/Main.storyboard
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BV1-FR-VrT">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tXr-a1-R10">
+            <objects>
+                <viewController id="BV1-FR-VrT" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="8aa-yV-Osq"/>
+                        <viewControllerLayoutGuide type="bottom" id="qHh-Mt-9TT"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="3se-qz-xqx">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L1M-Hb-9Sd">
+                                <rect key="frame" x="0.0" y="-1" width="375" height="668"/>
+                                <connections>
+                                    <segue destination="nkD-DT-mfF" kind="embed" id="Wkx-5J-8Mt"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="L1M-Hb-9Sd" firstAttribute="bottom" secondItem="3se-qz-xqx" secondAttribute="bottomMargin" id="EDu-Te-1Ex"/>
+                            <constraint firstItem="L1M-Hb-9Sd" firstAttribute="centerX" secondItem="3se-qz-xqx" secondAttribute="centerX" id="Wxj-vx-snT"/>
+                            <constraint firstItem="L1M-Hb-9Sd" firstAttribute="top" secondItem="3se-qz-xqx" secondAttribute="topMargin" constant="-1" id="b8F-eo-eeH"/>
+                            <constraint firstItem="L1M-Hb-9Sd" firstAttribute="leading" secondItem="3se-qz-xqx" secondAttribute="leadingMargin" constant="-16" id="fsO-QM-tff"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="SZV-WD-TEh" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="116" y="118.29085457271366"/>
+        </scene>
+        <!--OpenGL View Controller-->
+        <scene sceneID="WM4-7S-RYS">
+            <objects>
+                <viewController id="nkD-DT-mfF" customClass="OpenGLViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="qJp-1Z-Ulr"/>
+                        <viewControllerLayoutGuide type="bottom" id="hO5-p5-aqK"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="RcV-PY-aNg" customClass="OpenGLView">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="668"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dOQ-9J-rcK" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="897" y="-61"/>
+        </scene>
+    </scenes>
+</document>

--- a/src/Standalone_iOS/src/AppDelegate.m
+++ b/src/Standalone_iOS/src/AppDelegate.m
@@ -1,0 +1,9 @@
+#import "AppDelegate.h"
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    return YES;
+}
+
+@end

--- a/src/Standalone_iOS/src/BabylonManager.cpp
+++ b/src/Standalone_iOS/src/BabylonManager.cpp
@@ -1,0 +1,43 @@
+#include "BabylonManager.h"
+#include "basic_canvas.h"
+#include "HelloScene.h"
+
+// Babylon
+#include <babylon/engines/engine.h>
+#include <babylon/engines/scene.h>
+
+BabylonManager::BabylonManager(int width, int height):
+  _width(width),
+  _height(height),
+  _renderableScene(nullptr)
+{
+  _renderCanvas = std::make_unique<BasicCanvas>();
+  _renderCanvas->clientWidth = _width;
+  _renderCanvas->clientHeight = _height;
+  _renderCanvas->setFrameSize(_width, _height);
+  
+  _renderableScene = Samples::MakeHelloScene(_renderCanvas.get());
+  _renderableScene->initialize(_renderCanvas.get());
+}
+
+BabylonManager::~BabylonManager()
+{
+}
+
+void BabylonManager::render()
+{
+  // Render Scene
+  _renderableScene->render();
+}
+
+void BabylonManager::setSize(int width, int height)
+{
+  if(_width != width || _height != height)
+  {
+    _width = width;
+    _height = height;
+    
+    _renderCanvas->setFrameSize(_width, _height);
+    _renderableScene->getEngine()->resize();
+  }
+}

--- a/src/Standalone_iOS/src/BabylonView.mm
+++ b/src/Standalone_iOS/src/BabylonView.mm
@@ -1,0 +1,38 @@
+#import "BabylonView.h"
+#import "BabylonManager.h"
+
+@interface BabylonView()
+@property (nonatomic, readonly) BabylonManager* launcher;
+@end
+
+@implementation BabylonView
+
+- (instancetype)initWithSize:(CGSize)size
+{
+  if(self = [super init])
+  {
+    _launcher = new BabylonManager(size.width, size.height);
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  delete _launcher;
+}
+
+- (void)setSize:(CGSize)size
+{
+  _launcher->setSize(size.width, size.height);
+}
+
+- (void)render
+{
+  _launcher->render();
+}
+
+- (void)update
+{
+}
+
+@end

--- a/src/Standalone_iOS/src/HelloScene.cpp
+++ b/src/Standalone_iOS/src/HelloScene.cpp
@@ -1,0 +1,77 @@
+#include "HelloScene.h"
+
+#include <babylon/cameras/free_camera.h>
+#include <babylon/lights/hemispheric_light.h>
+#include <babylon/meshes/mesh.h>
+
+#include <babylon/engines/scene.h>
+#include <babylon/maths/color4.h>
+
+#include <babylon/cameras/arc_rotate_camera.h>
+#include <babylon/materials/standard_material.h>
+#include <babylon/materials/textures/mirror_texture.h>
+
+#include <iostream>
+#include <stdexcept>
+
+namespace Samples {
+using namespace BABYLON;
+
+// This files demonstrates how to create a very simple renderable scene
+struct HelloScene : public IRenderableScene
+{
+public:
+  HelloScene(ICanvas* iCanvas) : IRenderableScene(iCanvas)
+  {
+  }
+  
+  const char* getName() override { return "Hello Scene"; }
+
+  void initializeScene(ICanvas* canvas, Scene* scene) override
+  {
+    scene->clearColor = Color4(0.5f, 0.f, 0.f, 1.f);
+    
+    auto camera = ArcRotateCamera::New("camera1", 0.f, 0.f, 10.f, Vector3::Zero(), scene);
+    camera->setPosition(Vector3(0.f, 5.f, -10.f));
+    camera->attachControl(canvas, true);
+
+    camera->upperBetaLimit = Math::PI_2;
+    camera->lowerRadiusLimit = 4.f;
+
+    auto light = HemisphericLight::New("light1", Vector3(0.f, 1.f, 0.f), scene);
+    light->intensity = 0.7f;
+
+    auto knot = Mesh::CreateTorusKnot("knot", 1, 0.4f, 128, 64, 2, 3, scene);
+
+    // Mirror
+    auto mirror = Mesh::CreateBox("Mirror", 1.0, scene);
+    mirror->scaling = Vector3(100.f, 0.01f, 100.f);
+    auto mirrorMaterial = StandardMaterial::New("mirror", scene);
+    auto reflectionTexture = MirrorTexture::New("mirror", 1024.f, scene, true);
+    reflectionTexture->mirrorPlane = Plane(0.f, -1.f, 0.f, -2.f);
+    reflectionTexture->renderList = {knot.get()};
+    reflectionTexture->level = 1.f;
+    reflectionTexture->samples = 16;
+    mirrorMaterial->reflectionTexture = reflectionTexture;
+    mirror->material = mirrorMaterial;
+    mirror->position = Vector3(0.f, -2.f, 0.f);
+
+    // Main material
+    auto mainMaterial = StandardMaterial::New("main", scene);
+    knot->material = mainMaterial;
+    mainMaterial->diffuseColor = Color4(0.2f, 0.4f, 0.8f, 1.f);
+
+    // Fog
+    scene->fogMode  = Scene::FOGMODE_LINEAR;
+    scene->fogColor = scene->clearColor;
+    scene->fogStart = 20.f;
+    scene->fogEnd   = 50.f;
+  }
+};
+
+std::shared_ptr<IRenderableScene> MakeHelloScene(ICanvas* canvas)
+{
+  return std::make_shared<HelloScene>(canvas);
+}
+
+} // end of namespace Samples

--- a/src/Standalone_iOS/src/OpenGLViewController.m
+++ b/src/Standalone_iOS/src/OpenGLViewController.m
@@ -1,0 +1,135 @@
+#import "OpenGLViewController.h"
+#import <Foundation/Foundation.h>
+#import <OpenGLES/ES3/gl.h>
+#import "BabylonView.h"
+
+@implementation OpenGLView
+
++ (Class) layerClass
+{
+  return [CAEAGLLayer class];
+}
+
+@end
+
+@implementation OpenGLViewController
+{
+  OpenGLView* _view;
+  EAGLContext* _context;
+  GLuint _defaultFrameBuffer;
+  GLuint _colorRenderBuffer;
+  GLuint _depthRenderBuffer;
+  CAEAGLLayer* _eaglLayer;
+  CADisplayLink* _displayLink;
+  BabylonView* _babylonView;
+}
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  _view = (OpenGLView *)self.view;
+  [self prepareView];
+  [self makeCurrentContext];
+}
+
+- (void)draw:(id)sender
+{
+  [EAGLContext setCurrentContext:_context];
+  
+  glBindFramebuffer(GL_FRAMEBUFFER, _defaultFrameBuffer);
+  [_babylonView render];
+  
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glBindRenderbuffer(GL_RENDERBUFFER, _colorRenderBuffer);
+  
+  [_context presentRenderbuffer:GL_RENDERBUFFER];
+}
+
+- (void)makeCurrentContext
+{
+  [EAGLContext setCurrentContext:_context];
+}
+
+- (void)setupDisplayLink
+{
+  // Create the display link so that we render at 60FPS
+  _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(draw:)];
+  _displayLink.preferredFramesPerSecond = 60;
+  // Have the display link run on the default runn loop (and the main thread)
+  [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+}
+
+- (void)setupLayer
+{
+  // Get the layer
+  _eaglLayer = (CAEAGLLayer *)self.view.layer;
+  _eaglLayer.drawableProperties = @{kEAGLDrawablePropertyRetainedBacking : @NO, kEAGLDrawablePropertyColorFormat : kEAGLColorFormatRGBA8 };
+  _eaglLayer.opaque = YES;
+}
+
+- (void)setupContext
+{
+  _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
+  NSAssert(_context, @"Could Not Create OpenGL ES Context");
+  BOOL isSetCurrent = [EAGLContext setCurrentContext:_context];
+  NSAssert(isSetCurrent, @"Could not make OpenGL ES context current");
+}
+
+- (void)setupRenderBuffer:(CGSize)viewSize
+{
+  glGenRenderbuffers(1, &_depthRenderBuffer);
+  glBindRenderbuffer(GL_RENDERBUFFER, _depthRenderBuffer);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, viewSize.width, viewSize.height);
+  
+  glGenRenderbuffers(1, &_colorRenderBuffer);
+  glBindRenderbuffer(GL_RENDERBUFFER, _colorRenderBuffer);
+  
+  // On iOS & tvOS you must create an FBO and attach a CoreAnimation allocated drawable texture to use as the "defaultFBO" for a view
+  glGenFramebuffers(1, &_defaultFrameBuffer);
+  glBindFramebuffer(GL_FRAMEBUFFER, _defaultFrameBuffer);
+  
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, _colorRenderBuffer);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthRenderBuffer);
+}
+
+- (void)prepareView
+{
+  [self setupLayer];
+  [self setupContext];
+  CGSize viewSize = [self drawableSize];
+  _babylonView = [[BabylonView alloc] initWithSize:viewSize];
+  [self setupRenderBuffer:viewSize];
+  [_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:(id<EAGLDrawable>)_view.layer];
+  [self setupDisplayLink];
+}
+
+- (CGSize)drawableSize
+{
+  return [UIScreen mainScreen].bounds.size;
+}
+
+- (void)resizeDrawable
+{
+  [self makeCurrentContext];
+  CGSize drawSize = [self drawableSize];
+  
+  // Update size to Babylon
+  [_babylonView setSize:drawSize];
+  
+  // Ensure we've actually got a render buffer first;
+  assert(_colorRenderBuffer != 0);
+  glBindRenderbuffer(GL_RENDERBUFFER, _colorRenderBuffer);
+  [_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:(id<EAGLDrawable>)_view.layer];
+}
+
+- (void)viewDidLayoutSubviews
+{
+  [self resizeDrawable];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+  [self resizeDrawable];
+}
+
+@end

--- a/src/Standalone_iOS/src/basic_canvas.cpp
+++ b/src/Standalone_iOS/src/basic_canvas.cpp
@@ -1,0 +1,42 @@
+#include "basic_canvas.h"
+#include "gl_rendering_context.h"
+
+using namespace BABYLON;
+
+BasicCanvas::BasicCanvas() : ICanvas{}
+{
+  _renderingContext          = std::make_unique<GL::GLRenderingContext>();
+  _boundingClientRect.bottom = clientHeight;
+  _boundingClientRect.height = clientHeight;
+  _boundingClientRect.left   = 0;
+  _boundingClientRect.right  = clientWidth;
+  _boundingClientRect.top    = 0;
+  _boundingClientRect.width  = clientWidth;
+}
+
+BasicCanvas::~BasicCanvas()
+{
+}
+
+bool BasicCanvas::initializeContext3d()
+{
+  if (!_initialized) {
+    _initialized = _renderingContext->initialize();
+  }
+  return _initialized;
+}
+
+ClientRect& BasicCanvas::getBoundingClientRect()
+{
+  return _boundingClientRect;
+}
+
+ICanvasRenderingContext2D* BasicCanvas::getContext2d()
+{
+  return nullptr;
+}
+
+GL::IGLRenderingContext* BasicCanvas::getContext3d(const EngineOptions& /*options*/)
+{
+  return _renderingContext.get();
+}

--- a/src/Standalone_iOS/src/gl_rendering_context.cpp
+++ b/src/Standalone_iOS/src/gl_rendering_context.cpp
@@ -1,0 +1,1169 @@
+#include "gl_rendering_context.h"
+#include <array>
+#include <OpenGLES/ES3/gl.h>
+#include <babylon/core/logging.h>
+
+namespace BABYLON {
+namespace GL {
+
+void MessageCallback(GLenum /*source*/, GLenum type, GLuint /*id*/, GLenum severity,
+                     GLsizei /*length*/, const GLchar* message, const void* /*userParam*/)
+{
+  fprintf(stderr, "GL CALLBACK: %s type = 0x%x, severity = 0x%x, message = %s\n",
+          (type == DEBUG_TYPE_ERROR ? "** GL ERROR **" : ""), type, severity, message);
+}
+
+GLRenderingContext::GLRenderingContext()
+{
+  // Build map of string vs enums
+  // Textures
+  EnumMap["TEXTURE"]   = TEXTURE;
+  EnumMap["TEXTURE0"]  = TEXTURE0;
+  EnumMap["TEXTURE1"]  = TEXTURE1;
+  EnumMap["TEXTURE2"]  = TEXTURE2;
+  EnumMap["TEXTURE3"]  = TEXTURE3;
+  EnumMap["TEXTURE4"]  = TEXTURE4;
+  EnumMap["TEXTURE5"]  = TEXTURE5;
+  EnumMap["TEXTURE6"]  = TEXTURE6;
+  EnumMap["TEXTURE7"]  = TEXTURE7;
+  EnumMap["TEXTURE8"]  = TEXTURE8;
+  EnumMap["TEXTURE9"]  = TEXTURE9;
+  EnumMap["TEXTURE10"] = TEXTURE10;
+  EnumMap["TEXTURE11"] = TEXTURE11;
+  EnumMap["TEXTURE12"] = TEXTURE12;
+  EnumMap["TEXTURE13"] = TEXTURE13;
+  EnumMap["TEXTURE14"] = TEXTURE14;
+  EnumMap["TEXTURE15"] = TEXTURE15;
+  EnumMap["TEXTURE16"] = TEXTURE16;
+  EnumMap["TEXTURE17"] = TEXTURE17;
+  EnumMap["TEXTURE18"] = TEXTURE18;
+  EnumMap["TEXTURE19"] = TEXTURE19;
+  EnumMap["TEXTURE20"] = TEXTURE20;
+  EnumMap["TEXTURE21"] = TEXTURE21;
+  EnumMap["TEXTURE22"] = TEXTURE22;
+  EnumMap["TEXTURE23"] = TEXTURE23;
+  EnumMap["TEXTURE24"] = TEXTURE24;
+  EnumMap["TEXTURE25"] = TEXTURE25;
+  EnumMap["TEXTURE26"] = TEXTURE26;
+  EnumMap["TEXTURE27"] = TEXTURE27;
+  EnumMap["TEXTURE28"] = TEXTURE28;
+  EnumMap["TEXTURE29"] = TEXTURE29;
+  EnumMap["TEXTURE30"] = TEXTURE30;
+  EnumMap["TEXTURE31"] = TEXTURE31;
+  // Color attachments
+  EnumMap["COLOR_ATTACHMENT0"]  = COLOR_ATTACHMENT0;
+  EnumMap["COLOR_ATTACHMENT1"]  = COLOR_ATTACHMENT1;
+  EnumMap["COLOR_ATTACHMENT2"]  = COLOR_ATTACHMENT2;
+  EnumMap["COLOR_ATTACHMENT3"]  = COLOR_ATTACHMENT3;
+  EnumMap["COLOR_ATTACHMENT4"]  = COLOR_ATTACHMENT4;
+  EnumMap["COLOR_ATTACHMENT5"]  = COLOR_ATTACHMENT5;
+  EnumMap["COLOR_ATTACHMENT6"]  = COLOR_ATTACHMENT6;
+  EnumMap["COLOR_ATTACHMENT7"]  = COLOR_ATTACHMENT7;
+  EnumMap["COLOR_ATTACHMENT8"]  = COLOR_ATTACHMENT8;
+  EnumMap["COLOR_ATTACHMENT9"]  = COLOR_ATTACHMENT9;
+  EnumMap["COLOR_ATTACHMENT10"] = COLOR_ATTACHMENT10;
+  EnumMap["COLOR_ATTACHMENT11"] = COLOR_ATTACHMENT11;
+  EnumMap["COLOR_ATTACHMENT12"] = COLOR_ATTACHMENT12;
+  EnumMap["COLOR_ATTACHMENT13"] = COLOR_ATTACHMENT13;
+  EnumMap["COLOR_ATTACHMENT14"] = COLOR_ATTACHMENT14;
+  EnumMap["COLOR_ATTACHMENT15"] = COLOR_ATTACHMENT15;
+  EnumMap["COLOR_ATTACHMENT16"] = COLOR_ATTACHMENT16;
+  EnumMap["COLOR_ATTACHMENT17"] = COLOR_ATTACHMENT17;
+  EnumMap["COLOR_ATTACHMENT18"] = COLOR_ATTACHMENT18;
+  EnumMap["COLOR_ATTACHMENT19"] = COLOR_ATTACHMENT19;
+  EnumMap["COLOR_ATTACHMENT20"] = COLOR_ATTACHMENT20;
+  EnumMap["COLOR_ATTACHMENT21"] = COLOR_ATTACHMENT21;
+  EnumMap["COLOR_ATTACHMENT22"] = COLOR_ATTACHMENT22;
+  EnumMap["COLOR_ATTACHMENT23"] = COLOR_ATTACHMENT23;
+  EnumMap["COLOR_ATTACHMENT24"] = COLOR_ATTACHMENT24;
+  EnumMap["COLOR_ATTACHMENT25"] = COLOR_ATTACHMENT25;
+  EnumMap["COLOR_ATTACHMENT26"] = COLOR_ATTACHMENT26;
+  EnumMap["COLOR_ATTACHMENT27"] = COLOR_ATTACHMENT27;
+  EnumMap["COLOR_ATTACHMENT28"] = COLOR_ATTACHMENT28;
+  EnumMap["COLOR_ATTACHMENT29"] = COLOR_ATTACHMENT29;
+  EnumMap["COLOR_ATTACHMENT30"] = COLOR_ATTACHMENT30;
+  EnumMap["COLOR_ATTACHMENT31"] = COLOR_ATTACHMENT31;
+}
+
+GLRenderingContext::~GLRenderingContext() = default;
+
+std::string GlErrorCodeStr(GLenum error_code)
+{
+  std::string error;
+  switch (error_code) {
+    case GL_INVALID_ENUM:
+      error = "INVALID_ENUM";
+      break;
+    case GL_INVALID_VALUE:
+      error = "INVALID_VALUE";
+      break;
+    case GL_INVALID_OPERATION:
+      error = "INVALID_OPERATION";
+      break;
+    case GL_OUT_OF_MEMORY:
+      error = "OUT_OF_MEMORY";
+      break;
+    case GL_INVALID_FRAMEBUFFER_OPERATION:
+      error = "INVALID_FRAMEBUFFER_OPERATION";
+      break;
+  }
+  return error;
+}
+
+void glad_post_call_callback(const char* name, void* /*funcptr*/, int /*len_args*/, ...)
+{
+  GLenum error_code;
+  error_code = glGetError();
+
+  std::stringstream msg_str;
+  msg_str << "ERROR " << GlErrorCodeStr(error_code) << "(" << error_code << ") in " << name << "\n";
+  if (error_code != GL_NO_ERROR) {
+    fprintf(stderr, "%s", msg_str.str().c_str());
+  }
+}
+
+void glad_pre_call_callback(const char* name, void* /*funcptr*/, int /*len_args*/, ...)
+{
+  std::stringstream msg_str;
+  msg_str << "glad_pre_call_callback " << name << "\n";
+  fprintf(stderr, "%s", msg_str.str().c_str());
+}
+
+bool GLRenderingContext::initialize(bool enableGLDebugging)
+{
+  // Log the GL version
+  BABYLON_LOGF_INFO("GLRenderingContext", "Using GL version: %s", glGetString(GL_VERSION))
+  
+  // TODO: This is not supported in GLES 3, find an alternative
+  // Setup OpenGL options
+  //glEnable(GL_MULTISAMPLE);
+  
+  return true;
+}
+
+GLenum GLRenderingContext::operator[](const std::string& name)
+{
+  return EnumMap[name];
+}
+
+void GLRenderingContext::activeTexture(GLenum texture)
+{
+  glActiveTexture(texture);
+}
+
+void GLRenderingContext::attachShader(IGLProgram* program, IGLShader* shader)
+{
+  glAttachShader(program->value, shader ? shader->value : 0);
+}
+
+void GLRenderingContext::beginQuery(GLenum target, IGLQuery* query)
+{
+  glBeginQuery(target, query ? query->value : 0);
+}
+
+void GLRenderingContext::beginTransformFeedback(GLenum primitiveMode)
+{
+  glBeginTransformFeedback(primitiveMode);
+}
+
+void GLRenderingContext::bindAttribLocation(IGLProgram* program, GLuint index,
+                                            const std::string& name)
+{
+  glBindAttribLocation(program->value, index, name.c_str());
+}
+
+void GLRenderingContext::bindBuffer(GLenum target, IGLBuffer* buffer)
+{
+  glBindBuffer(target, buffer ? buffer->value : 0);
+}
+
+void GLRenderingContext::bindFramebuffer(GLenum target, IGLFramebuffer* framebuffer)
+{
+  glBindFramebuffer(target, framebuffer ? framebuffer->value : 0);
+}
+
+void GLRenderingContext::bindBufferBase(GLenum target, GLuint index, IGLBuffer* buffer)
+{
+  glBindBufferBase(target, index, buffer ? buffer->value : 0);
+}
+
+void GLRenderingContext::bindRenderbuffer(GLenum target, IGLRenderbuffer* renderbuffer)
+{
+  glBindRenderbuffer(target, renderbuffer ? renderbuffer->value : 0);
+}
+
+void GLRenderingContext::bindTexture(GLenum target, IGLTexture* texture)
+{
+  glBindTexture(target, texture ? texture->value : 0);
+}
+
+void GLRenderingContext::bindTransformFeedback(GLenum target,
+                                               IGLTransformFeedback* transformFeedback)
+{
+  glBindTransformFeedback(target, transformFeedback->value);
+}
+
+void GLRenderingContext::blendColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
+{
+  glBlendColor(red, green, blue, alpha);
+}
+
+void GLRenderingContext::blendEquation(GLenum mode)
+{
+  glBlendEquation(mode);
+}
+
+void GLRenderingContext::blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
+{
+  glBlendEquationSeparate(modeRGB, modeAlpha);
+}
+
+void GLRenderingContext::blendFunc(GLenum sfactor, GLenum dfactor)
+{
+  glBlendFunc(sfactor, dfactor);
+}
+
+void GLRenderingContext::blendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha,
+                                           GLenum dstAlpha)
+{
+  glBlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+}
+
+void GLRenderingContext::blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1,
+                                         GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1,
+                                         GLbitfield mask, GLenum filter)
+{
+  glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+}
+
+void GLRenderingContext::bufferData(GLenum target, GLsizeiptr sizeiptr, GLenum usage)
+{
+  glBufferData(target, sizeiptr >> 32, reinterpret_cast<any>(sizeiptr & 0x0000ffff), usage);
+}
+
+void GLRenderingContext::bufferData(GLenum target, const Float32Array& data, GLenum usage)
+{
+  glBufferData(target, static_cast<GLint>(data.size() * sizeof(GLfloat)), data.data(), usage);
+}
+
+void GLRenderingContext::bufferData(GLenum target, const Int32Array& data, GLenum usage)
+{
+  glBufferData(target, static_cast<GLint>(data.size() * sizeof(int32_t)), data.data(), usage);
+}
+
+void GLRenderingContext::bufferData(GLenum target, const Uint16Array& data, GLenum usage)
+{
+  glBufferData(target, static_cast<GLint>(data.size() * sizeof(uint16_t)), data.data(), usage);
+}
+
+void GLRenderingContext::bufferData(GLenum target, const Uint32Array& data, GLenum usage)
+{
+  glBufferData(target, static_cast<GLint>(data.size() * sizeof(uint32_t)), data.data(), usage);
+}
+
+void GLRenderingContext::bufferSubData(GLenum target, GLintptr offset, const Uint8Array& data)
+{
+  glBufferSubData(target, offset, static_cast<GLint>(data.size() * sizeof(GLbyte)), data.data());
+}
+
+void GLRenderingContext::bufferSubData(GLenum target, GLintptr offset, const Float32Array& data)
+{
+  glBufferSubData(target, offset, static_cast<GLint>(data.size() * sizeof(GLfloat)), data.data());
+}
+
+void GLRenderingContext::bufferSubData(GLenum target, GLintptr offset, Int32Array& data)
+{
+  glBufferSubData(target, offset, static_cast<GLint>(data.size() * sizeof(int32_t)), data.data());
+}
+
+void GLRenderingContext::bindVertexArray(GL::IGLVertexArrayObject* vao)
+{
+  glBindVertexArray(vao ? vao->value : 0);
+}
+
+GLenum GLRenderingContext::checkFramebufferStatus(GLenum target)
+{
+  return glCheckFramebufferStatus(target);
+}
+
+void GLRenderingContext::clear(GLbitfield mask)
+{
+  glClear(mask);
+}
+
+void GLRenderingContext::clearBufferfv(GLenum buffer, GLint drawbuffer,
+                                       const std::vector<GLfloat>& values, GLint /*srcOffset*/)
+{
+  glClearBufferfv(buffer, drawbuffer, values.data());
+}
+
+void GLRenderingContext::clearBufferiv(GLenum buffer, GLint drawbuffer,
+                                       const std::vector<GLint>& values, GLint /*srcOffset*/)
+{
+  glClearBufferiv(buffer, drawbuffer, values.data());
+}
+
+void GLRenderingContext::clearBufferuiv(GLenum buffer, GLint drawbuffer,
+                                        const std::vector<GLuint>& values, GLint /*srcOffset*/)
+{
+  glClearBufferuiv(buffer, drawbuffer, values.data());
+}
+
+void GLRenderingContext::clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth,
+                                       GLint stencil)
+{
+  glClearBufferfi(buffer, drawbuffer, depth, stencil);
+}
+
+void GLRenderingContext::clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
+{
+  glClearColor(red, green, blue, alpha);
+}
+
+void GLRenderingContext::clearDepth(GLclampf depth)
+{
+  glClearDepthf(depth);
+}
+
+void GLRenderingContext::clearStencil(GLint stencil)
+{
+  glClearStencil(stencil);
+}
+
+void GLRenderingContext::colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)
+{
+  glColorMask(red, green, blue, alpha);
+}
+
+void GLRenderingContext::compileShader(IGLShader* shader)
+{
+  glCompileShader(shader->value);
+}
+
+void GLRenderingContext::compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
+                                              GLint width, GLint height, GLint border,
+                                              const Uint8Array& pixels)
+{
+  glCompressedTexImage2D(target, level, internalformat, width, height, border,
+                         static_cast<GLint>(pixels.size() * sizeof(GLbyte)), &pixels[0]);
+}
+
+void GLRenderingContext::compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset,
+                                                 GLint yoffset, GLsizei width, GLsizei height,
+                                                 GLenum format, GLsizeiptr size)
+{
+  glCompressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format,
+                            static_cast<GLint>(size >> 32),
+                            reinterpret_cast<const GLint*>(size & 0x0000ffff));
+}
+
+void GLRenderingContext::copyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x,
+                                        GLint y, GLint width, GLint height, GLint border)
+{
+  glCopyTexImage2D(target, level, internalformat, x, y, width, height, border);
+}
+
+void GLRenderingContext::copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                                           GLint x, GLint y, GLint width, GLint height)
+{
+  glCopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
+}
+
+std::shared_ptr<IGLBuffer> GLRenderingContext::createBuffer()
+{
+  GLuint buffer = 0;
+  glGenBuffers(1, &buffer);
+  return std::make_shared<IGLBuffer>(buffer);
+}
+
+IGLFramebufferPtr GLRenderingContext::createFramebuffer()
+{
+  GLuint buffer = 0;
+  glGenFramebuffers(1, &buffer);
+  return std::make_shared<IGLFramebuffer>(buffer);
+}
+
+IGLProgramPtr GLRenderingContext::createProgram()
+{
+  return std::make_shared<IGLProgram>(glCreateProgram());
+}
+
+std::unique_ptr<IGLQuery> GLRenderingContext::createQuery()
+{
+  return std::make_unique<IGLQuery>(0);
+}
+
+IGLRenderbufferPtr GLRenderingContext::createRenderbuffer()
+{
+  GLuint buffer;
+  glGenRenderbuffers(1, &buffer);
+  return std::make_shared<IGLRenderbuffer>(buffer);
+}
+
+IGLShaderPtr GLRenderingContext::createShader(GLenum type)
+{
+  return std::make_shared<IGLShader>(glCreateShader(type));
+}
+
+IGLTexturePtr GLRenderingContext::createTexture()
+{
+  GLuint texture = 0;
+  glGenTextures(1, &texture);
+  return std::make_shared<IGLTexture>(texture);
+}
+
+IGLTransformFeedbackPtr GLRenderingContext::createTransformFeedback()
+{
+  GLuint transformFeedbackArray = 0;
+  glGenTransformFeedbacks(1, &transformFeedbackArray);
+  return std::make_shared<IGLTransformFeedback>(transformFeedbackArray);
+}
+
+IGLVertexArrayObjectPtr GLRenderingContext::createVertexArray()
+{
+  GLuint vertexArray = 0;
+  glGenVertexArrays(1, &vertexArray);
+  return std::make_shared<IGLVertexArrayObject>(vertexArray);
+}
+
+void GLRenderingContext::cullFace(GLenum mode)
+{
+  glCullFace(mode);
+}
+
+void GLRenderingContext::deleteBuffer(IGLBuffer* buffer)
+{
+  glDeleteBuffers(1, &buffer->value);
+  buffer->value = 0;
+}
+
+void GLRenderingContext::deleteFramebuffer(IGLFramebuffer* framebuffer)
+{
+  glDeleteFramebuffers(1, &framebuffer->value);
+  framebuffer->value = 0;
+}
+
+void GLRenderingContext::deleteProgram(IGLProgram* program)
+{
+  glDeleteProgram(program->value);
+}
+
+void GLRenderingContext::deleteQuery(IGLQuery* /*query*/)
+{
+}
+
+void GLRenderingContext::deleteRenderbuffer(IGLRenderbuffer* renderbuffer)
+{
+  glDeleteRenderbuffers(1, &renderbuffer->value);
+  renderbuffer->value = 0;
+}
+
+void GLRenderingContext::deleteShader(IGLShader* shader)
+{
+  glDeleteShader(shader ? shader->value : 0);
+}
+
+void GLRenderingContext::deleteTexture(IGLTexture* texture)
+{
+  glDeleteTextures(1, &texture->value);
+  texture->value = 0;
+}
+
+void GLRenderingContext::deleteTransformFeedback(IGLTransformFeedback* transformFeedback)
+{
+  glDeleteTransformFeedbacks(1, &transformFeedback->value);
+  transformFeedback->value = 0;
+}
+
+void GLRenderingContext::deleteVertexArray(IGLVertexArrayObject* vao)
+{
+  glDeleteVertexArrays(1, &vao->value);
+  vao->value = 0;
+}
+
+void GLRenderingContext::depthFunc(GLenum func)
+{
+  glDepthFunc(func);
+}
+
+void GLRenderingContext::depthMask(GLboolean flag)
+{
+  glDepthMask(flag);
+}
+
+void GLRenderingContext::depthRange(GLclampf zNear, GLclampf zFar)
+{
+  glDepthRangef(zNear, zFar);
+}
+
+void GLRenderingContext::detachShader(IGLProgram* program, IGLShader* shader)
+{
+  glDetachShader(program->value, shader->value);
+}
+
+void GLRenderingContext::disable(GLenum cap)
+{
+  glDisable(cap);
+}
+
+void GLRenderingContext::disableVertexAttribArray(GLuint index)
+{
+  glDisableVertexAttribArray(index);
+}
+
+void GLRenderingContext::drawArrays(GLenum mode, GLint first, GLint count)
+{
+  glDrawArrays(mode, first, count);
+}
+
+void GLRenderingContext::drawArraysInstanced(GLenum mode, GLint first, GLsizei count,
+                                             GLsizei instanceCount)
+{
+  glDrawArraysInstanced(mode, first, count, instanceCount);
+}
+
+void GLRenderingContext::drawBuffers(const std::vector<GLenum>& buffers)
+{
+  auto n = static_cast<GLsizei>(buffers.size());
+  glDrawBuffers(n, &buffers[0]);
+}
+
+void GLRenderingContext::drawElements(GLenum mode, GLint count, GLenum type, GLintptr offset)
+{
+  glDrawElements(mode, count, type, reinterpret_cast<any>(offset));
+}
+
+void GLRenderingContext::drawElementsInstanced(GLenum mode, GLsizei count, GLenum type,
+                                               GLintptr offset, GLsizei instanceCount)
+{
+  glDrawElementsInstanced(mode, count, type, reinterpret_cast<any>(offset), instanceCount);
+}
+
+void GLRenderingContext::enable(GLenum cap)
+{
+  glEnable(cap);
+}
+
+void GLRenderingContext::enableVertexAttribArray(GLuint index)
+{
+  glEnableVertexAttribArray(index);
+}
+
+void GLRenderingContext::endQuery(GLenum target)
+{
+  glEndQuery(target);
+}
+
+void GLRenderingContext::endTransformFeedback()
+{
+  glEndTransformFeedback();
+}
+
+void GLRenderingContext::finish()
+{
+  glFinish();
+}
+
+void GLRenderingContext::flush()
+{
+  glFlush();
+}
+
+void GLRenderingContext::framebufferRenderbuffer(GLenum target, GLenum attachment,
+                                                 GLenum renderbuffertarget,
+                                                 IGLRenderbuffer* renderbuffer)
+{
+  glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer->value);
+}
+
+void GLRenderingContext::framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget,
+                                              IGLTexture* texture, GLint level)
+{
+  glFramebufferTexture2D(target, attachment, textarget, texture->value, level);
+}
+
+void GLRenderingContext::framebufferTextureLayer(GLenum target, GLenum attachment,
+                                                 IGLTexture* texture, GLint level, GLint layer)
+{
+  glFramebufferTextureLayer(target, attachment, texture->value, level, layer);
+}
+
+void GLRenderingContext::framebufferTextureMultiviewOVR(GLenum /*target*/, GLenum /*attachment*/,
+                                                        IGLTexture* /*texture*/, GLint /*level*/,
+                                                        GLint /*baseViewIndex*/, GLint /*numViews*/)
+{
+}
+
+void GLRenderingContext::frontFace(GLenum mode)
+{
+  glFrontFace(mode);
+}
+
+void GLRenderingContext::generateMipmap(GLenum target)
+{
+  glGenerateMipmap(target);
+}
+
+std::vector<IGLShader*> GLRenderingContext::getAttachedShaders(IGLProgram* /*program*/)
+{
+  // Not supported
+  return std::vector<IGLShader*>();
+}
+
+GLint GLRenderingContext::getAttribLocation(IGLProgram* program, const std::string& name)
+{
+  return glGetAttribLocation(program->value, name.c_str());
+}
+
+GL::any GLRenderingContext::getExtension(const std::string& /*name*/)
+{
+  return nullptr;
+}
+
+bool GLRenderingContext::hasExtension(const std::string& /*extension*/)
+{
+  return true;
+}
+
+std::array<int, 3> GLRenderingContext::getScissorBoxParameter()
+{
+  return {{0, 0, 0}};
+}
+
+GLint GLRenderingContext::getParameteri(GLenum pname)
+{
+  GLint parameter = 0;
+  glGetIntegerv(pname, &parameter);
+  return parameter;
+}
+
+GLfloat GLRenderingContext::getParameterf(GLenum pname)
+{
+  GLfloat parameter = 0;
+  glGetFloatv(pname, &parameter);
+  return parameter;
+}
+
+GLboolean GLRenderingContext::getQueryParameterb(IGLQuery* query, GLenum pname)
+{
+  GLuint parameter = 0;
+  glGetQueryObjectuiv(query->value, pname, &parameter);
+  return parameter == GL_TRUE;
+}
+
+GLuint GLRenderingContext::getQueryParameteri(IGLQuery* query, GLenum pname)
+{
+  unsigned int parameter = 0;
+  glGetQueryObjectuiv(query->value, pname, &parameter);
+  return parameter;
+}
+
+std::string GLRenderingContext::getString(GLenum pname)
+{
+  const char* str = reinterpret_cast<const char*>(glGetString(pname));
+  return str ? std::string(str) : "";
+}
+
+GLint GLRenderingContext::getTexParameteri(GLenum pname)
+{
+  GLint parameter = 0;
+  glGetTexParameteriv(GL_TEXTURE_2D, pname, &parameter);
+  return parameter;
+}
+
+GLfloat GLRenderingContext::getTexParameterf(GLenum pname)
+{
+  GLfloat parameter = 0;
+  glGetTexParameterfv(GL_TEXTURE_2D, pname, &parameter);
+  return parameter;
+}
+
+GLenum GLRenderingContext::getError()
+{
+  return glGetError();
+}
+
+const char* GLRenderingContext::getErrorString(GLenum err)
+{
+  switch (err) {
+    case GL_INVALID_ENUM:
+      return "Invalid enum";
+    case GL_INVALID_OPERATION:
+      return "Invalid operation";
+    case GL_INVALID_VALUE:
+      return "Invalid value";
+    case GL_OUT_OF_MEMORY:
+      return "Out of memory";
+    default:
+      return "Unknown error";
+  }
+}
+
+GLint GLRenderingContext::getProgramParameter(IGLProgram* program, GLenum pname)
+{
+  GLint parameter = 0;
+  glGetProgramiv(program->value, pname, &parameter);
+  return parameter;
+}
+
+std::string GLRenderingContext::getProgramInfoLog(IGLProgram* program)
+{
+  GLint k = -1;
+  glGetProgramiv(program->value, GL_INFO_LOG_LENGTH, &k);
+  if (k <= 0) {
+    return "";
+  }
+
+  std::string result;
+  result.reserve(static_cast<size_t>(k + 1));
+  glGetProgramInfoLog(program->value, k, &k, const_cast<char*>(result.c_str()));
+  return result;
+}
+
+GLint GLRenderingContext::getRenderbufferParameter(GLenum target, GLenum pname)
+{
+  GLint params;
+  glGetRenderbufferParameteriv(target, pname, &params);
+  return params;
+}
+
+GLint GLRenderingContext::getShaderParameter(IGLShader* shader, GLenum pname)
+{
+  GLint parameter = 0;
+  glGetShaderiv(shader->value, pname, &parameter);
+  return parameter;
+}
+
+IGLShaderPrecisionFormat* GLRenderingContext::getShaderPrecisionFormat(GLenum /*shadertype*/,
+                                                                       GLenum /*precisiontype*/)
+{
+  return nullptr;
+}
+
+std::string GLRenderingContext::getShaderInfoLog(IGLShader* shader)
+{
+  GLint logSize = -1;
+  glGetShaderiv(shader->value, GL_INFO_LOG_LENGTH, &logSize);
+  if (logSize <= 0) {
+    return "";
+  }
+
+  // The maxLength includes the NULL character
+  auto logSizei = static_cast<GLbitfield>(logSize);
+  std::vector<GLchar> infoLog(logSizei);
+  glGetShaderInfoLog(shader->value, logSize, &logSize, &infoLog[0]);
+  return std::string(infoLog.begin(), infoLog.end());
+}
+
+std::string GLRenderingContext::getShaderSource(IGLShader* shader)
+{
+  GLchar buffer[5000];
+  GLsizei size;
+  glGetShaderSource(shader->value, 5000, &size, &buffer[0]);
+
+  return std::string(buffer, static_cast<std::size_t>(size) + 1);
+}
+
+GLuint GLRenderingContext::getUniformBlockIndex(IGLProgram* program,
+                                                const std::string& uniformBlockName)
+{
+  return glGetUniformBlockIndex(program->value, uniformBlockName.data());
+}
+
+std::unique_ptr<IGLUniformLocation> GLRenderingContext::getUniformLocation(IGLProgram* program,
+                                                                           const std::string& name)
+{
+  GLint value = glGetUniformLocation(program->value, name.c_str());
+  if (value != -1) {
+    return std::make_unique<IGLUniformLocation>(value);
+  }
+
+  return nullptr;
+}
+
+void GLRenderingContext::hint(GLenum target, GLenum mode)
+{
+  glHint(target, mode);
+}
+
+GLboolean GLRenderingContext::isBuffer(IGLBuffer* buffer)
+{
+  return glIsBuffer(buffer->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isEnabled(GLenum cap)
+{
+  return glIsEnabled(cap) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isFramebuffer(IGLFramebuffer* framebuffer)
+{
+  return glIsFramebuffer(framebuffer->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isProgram(IGLProgram* program)
+{
+  return glIsProgram(program->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isRenderbuffer(IGLRenderbuffer* renderbuffer)
+{
+  return glIsRenderbuffer(renderbuffer->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isShader(IGLShader* shader)
+{
+  return glIsShader(shader->value) == GL_TRUE;
+}
+
+GLboolean GLRenderingContext::isTexture(IGLTexture* texture)
+{
+  return glIsTexture(texture->value) == GL_TRUE;
+}
+
+void GLRenderingContext::lineWidth(GLfloat width)
+{
+  glLineWidth(width);
+}
+
+bool GLRenderingContext::linkProgram(IGLProgram* program)
+{
+  glLinkProgram(program->value);
+
+  // Test linker result.
+  GLint linkSucceed = GL_FALSE;
+  glGetProgramiv(program->value, GL_LINK_STATUS, &linkSucceed);
+
+  return linkSucceed != GL_FALSE;
+}
+
+void GLRenderingContext::pixelStorei(GLenum pname, GLint param)
+{
+  if (pname != UNPACK_FLIP_Y_WEBGL) {
+    glPixelStorei(pname, param);
+  }
+}
+
+void GLRenderingContext::polygonOffset(GLfloat factor, GLfloat units)
+{
+  glPolygonOffset(factor, units);
+}
+
+void GLRenderingContext::readBuffer(GLenum src)
+{
+  glReadBuffer(src);
+}
+
+void GLRenderingContext::readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format,
+                                    GLenum type, Float32Array& pixels)
+{
+  glReadPixels(x, y, width, height, format, type, &pixels[0]);
+}
+
+void GLRenderingContext::readPixels(GLint x, GLint y, GLint width, GLint height, GLenum format,
+                                    GLenum type, Uint8Array& pixels)
+{
+  glReadPixels(x, y, width, height, format, type, &pixels[0]);
+}
+
+void GLRenderingContext::renderbufferStorage(GLenum target, GLenum internalformat, GLint width,
+                                             GLint height)
+{
+  glRenderbufferStorage(target, internalformat, width, height);
+}
+
+void GLRenderingContext::renderbufferStorageMultisample(GLenum target, GLsizei samples,
+                                                        GLenum internalFormat, GLsizei width,
+                                                        GLsizei height)
+{
+  glRenderbufferStorageMultisample(target, samples, internalFormat, width, height);
+}
+
+void GLRenderingContext::sampleCoverage(GLclampf value, GLboolean invert)
+{
+  glSampleCoverage(value, invert);
+}
+
+void GLRenderingContext::scissor(GLint x, GLint y, GLint width, GLint height)
+{
+  glScissor(x, y, width, height);
+}
+
+void GLRenderingContext::shaderSource(IGLShader* shader, const std::string& source)
+{
+  auto length        = static_cast<int>(source.length());
+  const GLchar* line = source.c_str();
+  glShaderSource(shader->value, 1, &line, &length);
+}
+
+void GLRenderingContext::stencilFunc(GLenum func, GLint ref, GLuint mask)
+{
+  glStencilFunc(func, ref, mask);
+}
+
+void GLRenderingContext::stencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask)
+{
+  glStencilFuncSeparate(face, func, ref, mask);
+}
+
+void GLRenderingContext::stencilMask(GLuint mask)
+{
+  glStencilMask(mask);
+}
+
+void GLRenderingContext::stencilMaskSeparate(GLenum face, GLuint mask)
+{
+  glStencilMaskSeparate(face, mask);
+}
+
+void GLRenderingContext::stencilOp(GLenum fail, GLenum zfail, GLenum zpass)
+{
+  glStencilOp(fail, zfail, zpass);
+}
+
+void GLRenderingContext::stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass)
+{
+  glStencilOpSeparate(face, fail, zfail, zpass);
+}
+
+void GLRenderingContext::texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width,
+                                    GLsizei height, GLint border, GLenum format, GLenum type,
+                                    const Uint8Array* const pixels)
+{
+  if (pixels == nullptr) {
+    glTexImage2D(target, level, internalformat, width, height, border, format, type, nullptr);
+  }
+  else {
+    glTexImage2D(target, level, internalformat, width, height, border, format, type,
+                 pixels->data());
+  }
+}
+
+void GLRenderingContext::texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width,
+                                    GLsizei height, GLsizei depth, GLint border, GLenum format,
+                                    GLenum type, const Uint8Array& pixels)
+{
+  glTexImage3D(target, level, internalformat, width, height, depth, border, format, type,
+               &pixels[0]);
+}
+
+void GLRenderingContext::texParameterf(GLenum target, GLenum pname, GLfloat param)
+{
+  glTexParameterf(target, pname, param);
+}
+
+void GLRenderingContext::texParameteri(GLenum target, GLenum pname, GLint param)
+{
+  glTexParameteri(target, pname, param);
+}
+
+void GLRenderingContext::texStorage3D(GLenum target, GLint levels, GLenum internalformat,
+                                      GLsizei width, GLsizei height, GLsizei depth)
+{
+  glTexStorage3D(target, levels, internalformat, width, height, depth);
+}
+
+void GLRenderingContext::texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                                       GLint width, GLint height, GLenum format, GLenum type,
+                                       const Uint8Array& pixels)
+{
+  glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, &pixels[0]);
+}
+
+void GLRenderingContext::transformFeedbackVaryings(IGLProgram* program,
+                                                   const std::vector<std::string>& varyings,
+                                                   GLenum bufferMode)
+{
+  std::vector<const char*> _varyings;
+  for (auto varying : varyings) {
+    _varyings.emplace_back(varying.c_str());
+  }
+
+  glTransformFeedbackVaryings(program->value, static_cast<int>(varyings.size()), &_varyings[0],
+                              bufferMode);
+}
+
+void GLRenderingContext::uniform1f(IGLUniformLocation* location, GLfloat x)
+{
+  glUniform1f(location->value, x);
+}
+
+void GLRenderingContext::GLRenderingContext::uniform1fv(GL::IGLUniformLocation* uniform,
+                                                        const Float32Array& array)
+{
+  glUniform1fv(uniform->value, static_cast<int>(array.size() * sizeof(GLfloat)), array.data());
+}
+
+void GLRenderingContext::uniform1i(IGLUniformLocation* location, GLint x)
+{
+  glUniform1i(location->value, x);
+}
+
+void GLRenderingContext::uniform1iv(IGLUniformLocation* location, const Int32Array& v)
+{
+  glUniform1iv(location->value, static_cast<GLint>(v.size() * sizeof(int32_t)), v.data());
+}
+
+void GLRenderingContext::uniform2f(IGLUniformLocation* location, GLfloat x, GLfloat y)
+{
+  glUniform2f(location->value, x, y);
+}
+
+void GLRenderingContext::uniform2fv(IGLUniformLocation* location, const Float32Array& v)
+{
+  glUniform2fv(location->value, static_cast<GLint>(v.size() * sizeof(GLfloat)), v.data());
+}
+
+void GLRenderingContext::uniform2i(IGLUniformLocation* location, GLint x, GLint y)
+{
+  glUniform2i(location->value, x, y);
+}
+
+void GLRenderingContext::uniform2iv(IGLUniformLocation* location, const Int32Array& v)
+{
+  glUniform2iv(location->value, static_cast<GLint>(v.size() * sizeof(int32_t)), v.data());
+}
+
+void GLRenderingContext::uniform3f(IGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z)
+{
+  glUniform3f(location->value, x, y, z);
+}
+
+void GLRenderingContext::uniform3fv(IGLUniformLocation* location, const Float32Array& v)
+{
+  glUniform3fv(location->value, static_cast<GLint>(v.size() * sizeof(GLfloat)), v.data());
+}
+
+void GLRenderingContext::uniform3i(IGLUniformLocation* location, GLint x, GLint y, GLint z)
+{
+  glUniform3i(location->value, x, y, z);
+}
+
+void GLRenderingContext::uniform3iv(IGLUniformLocation* location, const Int32Array& v)
+{
+  glUniform3iv(location->value, static_cast<GLint>(v.size() * sizeof(int32_t)), v.data());
+}
+
+void GLRenderingContext::uniform4f(IGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z,
+                                   GLfloat w)
+{
+  glUniform4f(location->value, x, y, z, w);
+}
+
+void GLRenderingContext::uniform4fv(IGLUniformLocation* location, const Float32Array& v)
+{
+  glUniform4fv(location->value, static_cast<GLint>(v.size() * sizeof(GLfloat)), v.data());
+}
+
+void GLRenderingContext::uniform4i(IGLUniformLocation* location, GLint x, GLint y, GLint z, GLint w)
+{
+  glUniform4i(location->value, x, y, z, w);
+}
+
+void GLRenderingContext::uniform4iv(IGLUniformLocation* location, const Int32Array& v)
+{
+  glUniform4iv(location->value, static_cast<GLint>(v.size() * sizeof(int32_t)), v.data());
+}
+
+void GLRenderingContext::uniformBlockBinding(IGLProgram* program, GLuint uniformBlockIndex,
+                                             GLuint uniformBlockBinding)
+{
+  glUniformBlockBinding(program->value, uniformBlockIndex, uniformBlockBinding);
+}
+
+void GLRenderingContext::uniformMatrix2fv(IGLUniformLocation* location, GLboolean transpose,
+                                          const Float32Array& value)
+{
+  glUniformMatrix2fv(location->value, static_cast<GLint>(value.size() / 16), transpose,
+                     value.data());
+}
+
+void GLRenderingContext::uniformMatrix3fv(IGLUniformLocation* location, GLboolean transpose,
+                                          const Float32Array& value)
+{
+  glUniformMatrix3fv(location->value, static_cast<GLint>(value.size() / 16), transpose,
+                     value.data());
+}
+
+void GLRenderingContext::uniformMatrix4fv(IGLUniformLocation* location, GLboolean transpose,
+                                          const Float32Array& value)
+{
+  glUniformMatrix4fv(location->value, static_cast<GLint>(value.size() / 16), transpose,
+                     value.data());
+}
+
+void GLRenderingContext::uniformMatrix4fv(IGLUniformLocation* location, GLboolean transpose,
+                                          const std::array<float, 16>& value)
+{
+  glUniformMatrix4fv(location->value, static_cast<GLint>(value.size() / 16), transpose,
+                     value.data());
+}
+
+void GLRenderingContext::useProgram(IGLProgram* program)
+{
+  glUseProgram(program->value);
+}
+
+void GLRenderingContext::validateProgram(IGLProgram* program)
+{
+  glValidateProgram(program->value);
+}
+
+void GLRenderingContext::vertexAttrib1f(GLuint indx, GLfloat x)
+{
+  glVertexAttrib1f(indx, x);
+}
+
+void GLRenderingContext::vertexAttrib1fv(GLuint indx, Float32Array& values)
+{
+  glVertexAttrib1fv(indx, values.data());
+}
+
+void GLRenderingContext::vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y)
+{
+  glVertexAttrib2f(indx, x, y);
+}
+
+void GLRenderingContext::vertexAttrib2fv(GLuint indx, Float32Array& values)
+{
+  glVertexAttrib2fv(indx, values.data());
+}
+
+void GLRenderingContext::vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z)
+{
+  glVertexAttrib3f(indx, x, y, z);
+}
+
+void GLRenderingContext::vertexAttrib3fv(GLuint indx, Float32Array& values)
+{
+  glVertexAttrib3fv(indx, values.data());
+}
+
+void GLRenderingContext::vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w)
+{
+  glVertexAttrib4f(indx, x, y, z, w);
+}
+
+void GLRenderingContext::vertexAttrib4fv(GLuint indx, Float32Array& values)
+{
+  glVertexAttrib4fv(indx, values.data());
+}
+
+void GLRenderingContext::vertexAttribDivisor(GLuint index, GLuint divisor)
+{
+  glVertexAttribDivisor(index, divisor);
+}
+
+void GLRenderingContext::vertexAttribPointer(GLuint indx, GLint size, GLenum type,
+                                             GLboolean normalized, GLint stride, GLintptr offset)
+{
+  glVertexAttribPointer(indx, size, type, normalized, stride, reinterpret_cast<any>(offset));
+}
+
+void GLRenderingContext::viewport(GLint x, GLint y, GLint width, GLint height)
+{
+  glViewport(x, y, width, height);
+}
+
+} // end of namespace GL
+} // end of namespace BABYLON

--- a/src/Standalone_iOS/src/main.m
+++ b/src/Standalone_iOS/src/main.m
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+#import <TargetConditionals.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}


### PR DESCRIPTION
Adding 2 projects, one is a OSX example which uses opengl without using any other library like sdl or glad. The second adds an iOS project and configuration through cmake, making a project that will build on an iOS 12.0 device or simulator.
To configure for iOS, this command is used (similar to BabylonNative)
`cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=../external/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DDEPLOYMENT_TARGET=12 ..`

Also I've added another define variable check to distinguish which apple platform in system.cpp in both the `openBrowser` and `openFile` functions. This is due to the `system` api not being available in iOS.

To run on a iPhone or iPad device, once cmake configures the iOS xcode BabylonCpp project, select the Standalone_iOS target and in Signing & Capabilities select your Team if building on an iphone device. To run via the simulator, no signing configuration is needed.